### PR TITLE
Add profile-based genre module

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -31,7 +31,7 @@ Falls Meldungen erscheinen, befolge die Tipps. Zum Beispiel wird `htmlhint` erw�
 
 So behältst du jederzeit die Kontrolle über deine Dateien.
 
-## Genres-&-Zufall-Modul testen
+## Genre-Liste & Zufall testen
 
 1. Öffne den Ordner `modules` im Dateimanager.
 2. Doppelklicke auf `panel01.html`. Dein Browser zeigt das Modul an.
@@ -40,7 +40,7 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 5. Mit **Zufall** wählst du einen Eintrag zufällig aus. Darunter entsteht ein kleines Protokoll (Log) mit Uhrzeit.
 6. Über **Kopieren** landet das Ergebnis in der Zwischenablage. Der Button färbt sich kurz grün als Bestätigung.
 
-## Profilgewichtung nutzen
+## Genre-Profile verwenden
 
 1. Öffne `panel02.html` im Ordner `modules`.
 2. Gib einen Namen und optional eine Zahl bei **Gewichtung** ein (1 = selten, 10 = oft).
@@ -78,3 +78,22 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
    ```
    Das `-u` merkt sich das Ziel für zukünftige `git push`-Befehle.
 4. Holt vorher `git pull`, falls andere schon verändert haben. Dadurch werden die Daten zusammengeführt.
+
+## Fehlende Module
+
+- Persona-Switcher (zwischen Figuren wechseln)
+- Story-Sampler (zufällige Textideen)
+- Cover/Layout-Werkzeug
+
+## Weitere Laien-Tipps
+
+1. Neues Modul kopieren:
+   ```bash
+   cp modules/panel04.html modules/neues_panel.html
+   ```
+   Damit legst du eine Kopie an. Danach `<title>` und `<h2>` anpassen.
+2. In `modules.json` einen neuen Eintrag ergänzen.
+3. Selfcheck starten:
+   ```bash
+   bash tools/selfcheck.sh
+   ```

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -43,9 +43,9 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 ## Genre-Profile verwenden
 
 1. Öffne `panel02.html` im Ordner `modules`.
-2. Gib einen Namen und optional eine Zahl bei **Gewichtung** ein (1 = selten, 10 = oft).
-3. Trage deine Genres ein und klicke **Profil speichern**.
-4. Beim Klick auf **Zufall** wird zuerst ein Profil gemäß Gewichtung ausgewählt und daraus ein Genre angezeigt.
+2. Gib einen Profilnamen ein und ergänze deine Genres.
+3. Mit **Profil speichern** legst du die Liste an.
+4. Über **Zufall** erhältst du eines der Genres aus dem gewählten Profil.
 
 Die gespeicherten Module findest du gesammelt in `modules.json`.
 

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -138,4 +138,24 @@ Keine
    ```bash
    bash tools/update_placeholder.sh
    ```
-   Dadurch bleibt `platzhalter.txt` aktuell.
+Dadurch bleibt `platzhalter.txt` aktuell.
+
+## Noch mehr nützliche Befehle
+
+- **Lokalen Server starten (kleiner Test-Server)**
+  ```bash
+  python3 -m http.server
+  ```
+  Danach kannst du `http://localhost:8000` im Browser aufrufen.
+
+- **Commit-Historie anzeigen (Verlauf der Änderungen)**
+  ```bash
+  git log --oneline --graph
+  ```
+  So siehst du, wann welche Änderung gespeichert wurde.
+
+- **Unterschiede prüfen**
+  ```bash
+  git diff
+  ```
+  Dieser Befehl zeigt dir Zeile für Zeile an, was sich im Vergleich zum letzten Commit geändert hat.

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -57,6 +57,13 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 4. Wähle ein Profil aus der Liste und passe die Beschreibung bei Bedarf an.
 5. Mit **Kopieren** überträgst du die Beschreibung in die Zwischenablage.
 
+## Story-Sampler nutzen
+
+1. Öffne `panel06.html` im Ordner `modules`.
+2. Schreibe untereinander kurze Ideen.
+3. Mit **Speichern** sicherst du die Liste.
+4. **Zufall** wählt eine Idee, **Kopieren** überträgt sie.
+
 ## Weiterf\u00fchrende Tipps
 
 - **Browser-Speicher leeren (localStorage)**
@@ -89,7 +96,6 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 
 ## Fehlende Module
 
-- Story-Sampler (zufällige Textideen)
 - Cover/Layout-Werkzeug
 
 ## Weitere Laien-Tipps

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -64,6 +64,12 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 3. Mit **Speichern** sicherst du die Liste.
 4. **Zufall** wählt eine Idee, **Kopieren** überträgt sie.
 
+## Cover-Layout gestalten
+
+1. Öffne `panel07.html` im Ordner `modules`.
+2. Trage einen Titel ein.
+3. Wähle eine Farbe im Farbfeld.
+4. Klicke auf **Speichern**, die Vorschau zeigt dein Cover.
 ## Weiterf\u00fchrende Tipps
 
 - **Browser-Speicher leeren (localStorage)**
@@ -96,7 +102,7 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 
 ## Fehlende Module
 
-- Cover/Layout-Werkzeug
+Keine
 
 ## Weitere Laien-Tipps
 

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -166,3 +166,25 @@ Dadurch bleibt `platzhalter.txt` aktuell.
   git diff
   ```
   Dieser Befehl zeigt dir Zeile für Zeile an, was sich im Vergleich zum letzten Commit geändert hat.
+
+## Branches zusammenführen
+
+1. Stelle sicher, dass du auf dem Hauptzweig (**main**) bist:
+```bash
+git checkout main
+```
+2. Ziehe die neuesten Änderungen, damit alles aktuell ist:
+```bash
+git pull
+```
+3. Füge den Arbeitszweig (**work**) zusammen (*merge* bedeutet vereinen):
+```bash
+git merge work
+```
+4. Treten Konflikte auf, folge den Hinweisen im Terminal und korrigiere sie.
+5. Übertrage das Ergebnis wieder nach GitHub:
+```bash
+git push
+```
+Damit sind die Zweige vereint und online gesichert.
+

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -48,3 +48,15 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 4. Beim Klick auf **Zufall** wird zuerst ein Profil gemäß Gewichtung ausgewählt und daraus ein Genre angezeigt.
 
 Die gespeicherten Module findest du gesammelt in `modules.json`.
+
+## Weiterf\u00fchrende Tipps
+
+- **Browser-Speicher leeren (localStorage)**
+  1. Modul im Browser öffnen.
+  2. Taste F12 drücken und "Konsole" auswählen.
+  3. `localStorage.clear()` eintippen und Enter drücken. (Löscht den Browser-Zwischenspeicher.)
+
+- **Projekt erneut prüfen**
+  1. `git status` ausführen.
+  2. `bash tools/selfcheck.sh` starten.
+  3. Fehlermeldungen beachten und Befehle wie `npm install -g htmlhint` nutzen.

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -39,3 +39,12 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 4. Klicke auf **Speichern**. Die Liste wird in `localStorage` (Browser-Zwischenspeicher) gesichert.
 5. Mit **Zufall** wählst du einen Eintrag zufällig aus. Darunter entsteht ein kleines Protokoll (Log) mit Uhrzeit.
 6. Über **Kopieren** landet das Ergebnis in der Zwischenablage. Der Button färbt sich kurz grün als Bestätigung.
+
+## Profilgewichtung nutzen
+
+1. Öffne `panel02.html` im Ordner `modules`.
+2. Gib einen Namen und optional eine Zahl bei **Gewichtung** ein (1 = selten, 10 = oft).
+3. Trage deine Genres ein und klicke **Profil speichern**.
+4. Beim Klick auf **Zufall** wird zuerst ein Profil gemäß Gewichtung ausgewählt und daraus ein Genre angezeigt.
+
+Die gespeicherten Module findest du gesammelt in `modules.json`.

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -44,8 +44,10 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 
 1. Öffne `panel02.html` im Ordner `modules`.
 2. Gib einen Profilnamen ein und ergänze deine Genres.
-3. Mit **Profil speichern** legst du die Liste an.
-4. Über **Zufall** erhältst du eines der Genres aus dem gewählten Profil.
+3. Wähle bei Bedarf eine **Gewichtung** (Zahl bestimmt, wie oft das Profil gezogen wird).
+4. Mit **Profil speichern** legst du die Liste an.
+5. Über **Zufall** erhältst du eines der Genres aus dem gewählten Profil.
+6. Mit **Gewichteter Zufall** wird ein Profil nach Gewicht gewählt und daraus ein Genre angezeigt.
 
 Die gespeicherten Module findest du gesammelt in `modules.json`.
 

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -49,6 +49,14 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 
 Die gespeicherten Module findest du gesammelt in `modules.json`.
 
+## Persona-Switcher nutzen
+
+1. Öffne `panel05.html` im Ordner `modules`.
+2. Trage einen Namen und eine kurze Beschreibung ein.
+3. Klicke auf **Profil speichern**. Der Eintrag landet in der Auswahlliste.
+4. Wähle ein Profil aus der Liste und passe die Beschreibung bei Bedarf an.
+5. Mit **Kopieren** überträgst du die Beschreibung in die Zwischenablage.
+
 ## Weiterf\u00fchrende Tipps
 
 - **Browser-Speicher leeren (localStorage)**
@@ -81,7 +89,6 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 
 ## Fehlende Module
 
-- Persona-Switcher (zwischen Figuren wechseln)
 - Story-Sampler (zufällige Textideen)
 - Cover/Layout-Werkzeug
 
@@ -97,3 +104,12 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
    ```bash
    bash tools/selfcheck.sh
    ```
+4. Aufgabenliste aktualisieren:
+   ```bash
+   nano todo.txt
+   ```
+   Änderungen speichern (**Strg+O**) und schließen (**Strg+X**). Danach:
+   ```bash
+   bash tools/update_placeholder.sh
+   ```
+   Dadurch bleibt `platzhalter.txt` aktuell.

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -78,6 +78,12 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 1. Öffne `panel08.html` im Ordner `modules`.
 2. Wähle im Feld **Farbmodus** eines der Themes aus.
 3. Klicke auf **Übernehmen**. Das Aussehen passt sich an und wird gespeichert.
+## Einstellungen anpassen
+
+1. Öffne `panel09.html` im Ordner `modules`.
+2. Wähle eine **Schriftart** und gib eine **Schriftgröße** ein (Zahl in Pixel).
+3. Bestimme die **Button-Rundung** in der Auswahlliste.
+4. Drücke **Speichern**, damit die Angaben im Browser bleiben.
 ## Weiterf\u00fchrende Tipps
 
 - **Browser-Speicher leeren (localStorage)**

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -60,3 +60,21 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
   1. `git status` ausführen.
   2. `bash tools/selfcheck.sh` starten.
   3. Fehlermeldungen beachten und Befehle wie `npm install -g htmlhint` nutzen.
+
+## Fortschritte auf GitHub hochladen
+
+1. Prüfe, ob ein sogenanntes *Remote* (Verknüpfung zum Online-Repository) vorhanden ist:
+   ```bash
+   git remote -v
+   ```
+   Siehst du nichts, musst du die Verbindung anlegen.
+2. Verbinde dein Projekt mit GitHub. Ersetze `DEINNAME` durch deinen Benutzernamen:
+   ```bash
+   git remote add origin https://github.com/DEINNAME/modultool.git
+   ```
+3. Lade deine gespeicherten Änderungen hoch:
+   ```bash
+   git push -u origin main
+   ```
+   Das `-u` merkt sich das Ziel für zukünftige `git push`-Befehle.
+4. Holt vorher `git pull`, falls andere schon verändert haben. Dadurch werden die Daten zusammengeführt.

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -72,6 +72,12 @@ Die gespeicherten Module findest du gesammelt in `modules.json`.
 2. Trage einen Titel ein.
 3. Wähle eine Farbe im Farbfeld.
 4. Klicke auf **Speichern**, die Vorschau zeigt dein Cover.
+
+## Theme-Switcher nutzen
+
+1. Öffne `panel08.html` im Ordner `modules`.
+2. Wähle im Feld **Farbmodus** eines der Themes aus.
+3. Klicke auf **Übernehmen**. Das Aussehen passt sich an und wird gespeichert.
 ## Weiterf\u00fchrende Tipps
 
 - **Browser-Speicher leeren (localStorage)**

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -31,6 +31,13 @@ Falls Meldungen erscheinen, befolge die Tipps. Zum Beispiel wird `htmlhint` erw�
 
 So behältst du jederzeit die Kontrolle über deine Dateien.
 
+## Mit der Tastatur arbeiten
+
+1. Du kannst alle Module auch ohne Maus bedienen.
+2. Drücke die **Tabulator-Taste**. Damit springt der Fokus (Markierung) zum nächsten Bedienelement.
+3. Die Buttons zeigen nun einen gut sichtbaren Rahmen (Fokus-Ring). Mit **Enter** löst du den gewählten Button aus.
+4. So navigierst du komfortabel nur mit der Tastatur.
+
 ## Genre-Liste & Zufall testen
 
 1. Öffne den Ordner `modules` im Dateimanager.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 - **📋 Panel04: Textbausteine**
   → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
+- **🧑‍🎤 Panel05: Persona-Switcher**
+  → Verschiedene Figurenprofile speichern und auswählen
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
-- **Geplante Module:** Persona-Switcher (Panel05), Story-Sampler (Panel06), Cover/Layout (Panel07)
+- **Geplante Module:** Story-Sampler (Panel06), Cover/Layout (Panel07)
 ---
 
 ## 🧠 Features

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Kurze Ideen sammeln und zufällig auswählen
 - **🖼️ Panel07: Cover-Layout**
   → Einfacher Titel und Farbvorschau für Cover
+- **🎨 Panel08: Theme-Switcher**
+  → Farbmodus (dunkel, hell, blau) wählen und speichern
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Verschiedene Figurenprofile speichern und auswählen
 - **🖖 Panel06: Story-Sampler**
   → Kurze Ideen sammeln und zufällig auswählen
+- **🖼️ Panel07: Cover-Layout**
+  → Einfacher Titel und Farbvorschau für Cover
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
-- **Geplante Module:** Cover/Layout (Panel07)
 ---
 
 ## 🧠 Features

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 
 ## 🧩 Aktuelle Start-Module
 
+---
 - **📝 Panel01: Genres & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
 - **🎛 Panel02: Genre-Profile**
@@ -24,7 +25,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 - **📋 Panel04: Text-Templates**
   → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
-
+- **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
 ---
 
 ## 🧠 Features

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 ## 🧩 Aktuelle Start-Module
 
 ---
-- **📝 Panel01: Genres & Zufall**
+- **📝 Panel01: Genre-Liste & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
-- **🎛 Panel02: Genre-Profile**
-  → Mehrere Genre-Listen als Profile speichern, Zufallswahl jetzt mit Profilgewichtung
-- **📊 Panel03: Dashboard-Log**
+- **🎛 Panel02: Genre-Profile (Gewichtung)**
+  → Mehrere Genre-Listen unter Profilnamen speichern und gewichten
+- **📊 Panel03: Dashboard – Verlauf**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
-- **📋 Panel04: Text-Templates**
+- **📋 Panel04: Textbausteine**
   → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
+- **Geplante Module:** Persona-Switcher (Panel05), Story-Sampler (Panel06), Cover/Layout (Panel07)
 ---
 
 ## 🧠 Features

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 ---
 - **📝 Panel01: Genre-Liste & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
-- **🎛 Panel02: Genre-Profile (Gewichtung)**
-  → Mehrere Genre-Listen unter Profilnamen speichern und gewichten
+- **🎛 Panel02: Genre-Profile**
+  → Mehrere Genre-Listen unter Profilnamen speichern
 - **📊 Panel03: Dashboard – Verlauf**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 - **📋 Panel04: Textbausteine**

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Einfacher Titel und Farbvorschau für Cover
 - **🎨 Panel08: Theme-Switcher**
   → Farbmodus (dunkel, hell, blau) wählen und speichern
+- **⚙️ Panel09: Einstellungen**
+  → Schriftart, Größe und Button-Rundung global anpassen
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
 - **🎛 Panel02: Genre-Profile**
   → Mehrere Genre-Listen unter eigenen Profilnamen verwalten und per Zufall ausgeben
+- **📊 Panel03: Dashboard-Log**
+  → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 - **📝 Panel01: Genre-Liste & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
 - **🎛 Panel02: Genre-Profile**
-  → Mehrere Genre-Listen unter Profilnamen speichern
+  → Mehrere Genre-Listen unter Profilnamen speichern, optional mit Gewichtung
+  → Button "Gewichteter Zufall" wählt ein Profil nach Gewicht und daraus ein Genre
 - **📊 Panel03: Dashboard – Verlauf**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 - **📋 Panel04: Textbausteine**

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 
 - **📝 Panel01: Genres & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
+- **🎛 Panel02: Genre-Profile**
+  → Mehrere Genre-Listen unter eigenen Profilnamen verwalten und per Zufall ausgeben
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Mehrere Genre-Listen unter eigenen Profilnamen verwalten und per Zufall ausgeben
 - **📊 Panel03: Dashboard-Log**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
+- **📋 Panel04: Text-Templates**
+  → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - **⚙️ Panel09: Einstellungen**
   → Schriftart (Font), Größe und Button-Rundung global anpassen. Dadurch haben alle Module den gleichen Stil.
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
+- **Sichtbarer Tastaturfokus** erleichtert die Navigation per Tastatur
 ---
 
 ## 🧠 Features
@@ -44,6 +45,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - Drag & Drop für Medien, Module, Templates
 - Undo-/Redo-System, ZIP-Export, Selfcheck (Fehlerprüfung via `bash tools/selfcheck.sh`)
 - Live-Vorschau, große Bedienelemente, Einstellungs-Panel
+- Gut sichtbarer Tastaturfokus zur einfachen Navigation
 - Projektordner-Management + Fehlerkorrektur
 
 ---

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 📁 .github/workflows/ (validate.yml)
 📄 modules.json (Registrierung vorhandener Module)
 ```
+
+## 🔀 Branches zusammenführen
+Einfache Anleitung findest du in **LAIENHILFE.md** unter dem Abschnitt "Branches zusammenführen".

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 - **📝 Panel01: Genres & Zufall**
   → Listeneingabe, Speicherung und Zufallswahl mit Log & Kopierfunktion
 - **🎛 Panel02: Genre-Profile**
-  → Mehrere Genre-Listen unter eigenen Profilnamen verwalten und per Zufall ausgeben
+  → Mehrere Genre-Listen als Profile speichern, Zufallswahl jetzt mit Profilgewichtung
 - **📊 Panel03: Dashboard-Log**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
 - **📋 Panel04: Text-Templates**
@@ -46,3 +46,5 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 📁 logs/
 📁 tools/ (selfcheck.sh – sichert todo.txt und aktualisiert platzhalter.txt)
 📁 .github/workflows/ (validate.yml)
+📄 modules.json (Registrierung vorhandener Module)
+```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
   → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
 - **🧑‍🎤 Panel05: Persona-Switcher**
   → Verschiedene Figurenprofile speichern und auswählen
+- **🖖 Panel06: Story-Sampler**
+  → Kurze Ideen sammeln und zufällig auswählen
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
-- **Geplante Module:** Story-Sampler (Panel06), Cover/Layout (Panel07)
+- **Geplante Module:** Cover/Layout (Panel07)
 ---
 
 ## 🧠 Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🧰 Modultool
 
-**Modulares Content-Creation-Tool mit Fokus auf Barrierefreiheit, Systemkritik & Selbstheilung.**  
-Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaffende.
+**Modulares Content-Creation-Tool (Werkzeug zur Inhaltserstellung) mit Fokus auf Barrierefreiheit, Systemkritik und Selbstheilung.**
+Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content-Schaffende.
 
 ---
 
@@ -35,14 +35,14 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstler & Content-Schaff
 - **🎨 Panel08: Theme-Switcher**
   → Farbmodus (dunkel, hell, blau) wählen und speichern
 - **⚙️ Panel09: Einstellungen**
-  → Schriftart, Größe und Button-Rundung global anpassen
+  → Schriftart (Font), Größe und Button-Rundung global anpassen. Dadurch haben alle Module den gleichen Stil.
 - **Statusmeldungen** informieren, wenn Eingaben fehlen oder das Kopieren nicht klappt
 ---
 
 ## 🧠 Features
 
 - Drag & Drop für Medien, Module, Templates
-- Undo-/Redo-System, ZIP-Export, Selfcheck
+- Undo-/Redo-System, ZIP-Export, Selfcheck (Fehlerprüfung via `bash tools/selfcheck.sh`)
 - Live-Vorschau, große Bedienelemente, Einstellungs-Panel
 - Projektordner-Management + Fehlerkorrektur
 

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -47,7 +47,7 @@
 - **Sofort-Feedback**, **Hilfetexte**, **Ein-Klick‑Buttons**
 - **Hover-Vorschau**, **große Touch-Flächen**, **logische Struktur**
 - **Drag & Drop**, **Undo/Redo**, **ZIP-Backup**
-- **Filter, Favoriten**, **Scrollsync**, **Einstellungs-Panel**
+- **Filter, Favoriten**, **Scrollsync**, **Einstellungs-Panel ✅**
 - **Projektordner-Startwahl**, **Autofokus + Clear-Buttons**
 
 ### 🕸 Globale Technische Standards

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -37,8 +37,9 @@
 ### 🌟 Erweiterte Kreativmodule
 - Persona-Switcher  
 - Story-Sampler  
-- Cover/Layout-Modul  
-- Projektorganizer  
+- Cover/Layout-Modul
+- Theme-Switcher
+- Projektorganizer
 - Asset-Finder  
 - Quote/Line-Manager  
 
@@ -72,9 +73,10 @@
 ---
 
 ### Panel07‑09: Erweiterungsmodule
-- Persona-Switcher: ✅  
-- Story-Sampler: ✅  
-- Cover/Layout: ✅  
+- Persona-Switcher: ✅
+- Story-Sampler: ✅
+- Cover/Layout: ✅
+- Theme-Switcher: ✅
 
 ---
 

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -97,7 +97,7 @@ priority: hoch
 tasks:
   - UI-Layout mit Grid/Flex und ARIA/Fokus
   - JS: commaSplit -> uniqueSort -> JSON-Save/Load
-  - Zufallsmodi + Profilgewichtung umsetzen ⬜ offen
+  - Zufallsmodi + Profilgewichtung umsetzen ✅ umgesetzt
   - Logging + Dashboard-Integration
   - Clipboard-Ziel + farbiges Feedback
   - CSS responsiv + Test via Axe/WAVE

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -95,7 +95,7 @@ priority: hoch
 tasks:
   - UI-Layout mit Grid/Flex und ARIA/Fokus
   - JS: commaSplit -> uniqueSort -> JSON-Save/Load
-  - Zufallsmodi + Profil/Gewichtung implementieren ✅ erledigt
+  - Zufallsmodi + Profilgewichtung umsetzen ⬜ offen
   - Logging + Dashboard-Integration
   - Clipboard-Ziel + farbiges Feedback
   - CSS responsiv + Test via Axe/WAVE

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -72,8 +72,8 @@
 ---
 
 ### Panel07‑09: Erweiterungsmodule
-- Persona-Switcher: ⬜  
-- Story-Sampler: ⬜  
+- Persona-Switcher: ✅  
+- Story-Sampler: ✅  
 - Cover/Layout: ⬜  
 
 ---

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -74,7 +74,7 @@
 ### Panel07‑09: Erweiterungsmodule
 - Persona-Switcher: ✅  
 - Story-Sampler: ✅  
-- Cover/Layout: ⬜  
+- Cover/Layout: ✅  
 
 ---
 

--- a/VISION_AGENTS.md
+++ b/VISION_AGENTS.md
@@ -95,7 +95,7 @@ priority: hoch
 tasks:
   - UI-Layout mit Grid/Flex und ARIA/Fokus
   - JS: commaSplit -> uniqueSort -> JSON-Save/Load
-  - Zufallsmodi + Profil/Gewichtung implementieren
+  - Zufallsmodi + Profil/Gewichtung implementieren ✅ erledigt
   - Logging + Dashboard-Integration
   - Clipboard-Ziel + farbiges Feedback
   - CSS responsiv + Test via Axe/WAVE

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716224353.txt
+./data/todo_backup_20250716224904.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html
@@ -19,6 +19,7 @@
 ./modules/panel03.html
 ./modules/panel04.html
 ./modules/panel05.html
+./modules/panel06.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,9 +11,10 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716042413.txt
+./data/todo_backup_20250716213701.txt
 ./index-DDD.html
 ./modules/panel01.html
+./modules/panel02.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,8 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716215714.txt
-./data/todo_backup_20250716215744.txt
+./data/todo_backup_20250716221300.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716222651.txt
+./data/todo_backup_20250716223339.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716222006.txt
+./data/todo_backup_20250716222651.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,9 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716230324.txt
-./data/todo_backup_20250716230346.txt
-./data/todo_backup_20250716230406.txt
+./data/todo_backup_20250716231301.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html
@@ -23,6 +21,7 @@
 ./modules/panel05.html
 ./modules/panel06.html
 ./modules/panel07.html
+./modules/panel08.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,8 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716231935.txt
+./data/todo_backup_20250716232458.txt
+./data/todo_backup_20250716232512.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,11 +11,12 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716214242.txt
+./data/todo_backup_20250716214910.txt
 ./index-DDD.html
 ./modules/panel01.html
 ./modules/panel02.html
 ./modules/panel03.html
+./modules/panel04.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -1,3 +1,4 @@
+./.README.md.swp
 ./.editorconfig
 ./.github/workflows/branch-limit.yml
 ./.github/workflows/validate.yml
@@ -11,7 +12,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716224904.txt
+./data/todo_backup_20250716225413.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html
@@ -20,6 +21,7 @@
 ./modules/panel04.html
 ./modules/panel05.html
 ./modules/panel06.html
+./modules/panel07.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,10 +11,11 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716213701.txt
+./data/todo_backup_20250716214242.txt
 ./index-DDD.html
 ./modules/panel01.html
 ./modules/panel02.html
+./modules/panel03.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716231301.txt
+./data/todo_backup_20250716231935.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html
@@ -22,6 +22,7 @@
 ./modules/panel06.html
 ./modules/panel07.html
 ./modules/panel08.html
+./modules/panel09.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,8 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716232458.txt
-./data/todo_backup_20250716232512.txt
+./data/todo_backup_20250716233209.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,13 +11,14 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716223339.txt
+./data/todo_backup_20250716224353.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html
 ./modules/panel02.html
 ./modules/panel03.html
 ./modules/panel04.html
+./modules/panel05.html
 ./platzhalter.txt
 ./setup.sh
 ./todo.txt

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,9 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716225959.txt
+./data/todo_backup_20250716230324.txt
+./data/todo_backup_20250716230346.txt
+./data/todo_backup_20250716230406.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716221300.txt
+./data/todo_backup_20250716222006.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,8 +11,10 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716214910.txt
+./data/todo_backup_20250716215714.txt
+./data/todo_backup_20250716215744.txt
 ./index-DDD.html
+./modules.json
 ./modules/panel01.html
 ./modules/panel02.html
 ./modules/panel03.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -1,4 +1,3 @@
-./.README.md.swp
 ./.editorconfig
 ./.github/workflows/branch-limit.yml
 ./.github/workflows/validate.yml
@@ -12,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716225413.txt
+./data/todo_backup_20250716225959.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716233209.txt
+./data/todo_backup_20250716233816.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -1,7 +1,7 @@
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [x] UX-Layout mit Grid/Flex und ARIA-Fokus verbessern
 - [x] commaSplit -> uniqueSort -> JSON-Save/Load umsetzen
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -11,7 +11,7 @@
 - [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
-- [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [x] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
@@ -20,3 +20,4 @@
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
+- [x] Branches zusammenführen (work -> main)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -13,5 +13,5 @@
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
-- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -14,4 +14,4 @@
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
-- [ ] Cover/Layout-Modul umsetzen (Panel07)
+- [x] Cover/Layout-Modul umsetzen (Panel07)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -8,7 +8,7 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung umsetzen
+- [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -8,7 +8,7 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung umsetzen
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -15,3 +15,5 @@
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
+
+- [x] Theme-Switcher-Modul umsetzen (Panel08)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -4,6 +4,8 @@
 - [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
-- [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] CSS responsiv machen, Test mit Axe/WAVE
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
+- [x] Text-Templates-Modul (Panel04) umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung implementieren

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -12,6 +12,6 @@
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
-- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [ ] Story-Sampler-Modul umsetzen (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -10,3 +10,4 @@
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -18,3 +18,4 @@
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
+- [x] Weitere Befehle in der Laienhilfe ergänzen

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -17,3 +17,4 @@
 - [x] Cover/Layout-Modul umsetzen (Panel07)
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
+- [x] Einstellungs-Panel umsetzen (Panel09)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -5,4 +5,5 @@
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -8,4 +8,4 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsmodi mit Profilgewichtung umgesetzt

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -10,4 +10,8 @@
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -9,3 +9,4 @@
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -19,3 +19,4 @@
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
+- [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)

--- a/index-DDD.html
+++ b/index-DDD.html
@@ -43,6 +43,9 @@
       --highlight: #46c1f6;
       --field-border: #2ccfa0;
       --field-error: #c53c3c;
+      --base-font: 16px;
+      --font-family: 'Segoe UI', Arial, sans-serif;
+      --btn-radius: 0.5rem;
     }
     [data-theme="light"] {
       --bg: #f9fafc;
@@ -107,7 +110,7 @@
 
     html, body {
       min-height: 100vh; width: 100vw; background: var(--bg); color: var(--text); margin:0; padding:0;
-      font-family: 'Segoe UI', Arial, sans-serif; font-size: 16px; line-height: 1.5;
+      font-family: var(--font-family, 'Segoe UI', Arial, sans-serif); font-size: var(--base-font, 16px); line-height:1.5;
       overflow-x: hidden;
     }
     header, footer {

--- a/modules.json
+++ b/modules.json
@@ -1,7 +1,32 @@
 [
-  {"id":"panel01","title":"Genre-Liste & Zufall","file":"modules/panel01.html"},
-  {"id":"panel02","title":"Genre-Profile","file":"modules/panel02.html"},
-  {"id":"panel03","title":"Dashboard – Verlauf","file":"modules/panel03.html"},
-  {"id":"panel04","title":"Textbausteine","file":"modules/panel04.html"},
-  {"id":"panel05","title":"Persona-Switcher","file":"modules/panel05.html"}
+  {
+    "id": "panel01",
+    "title": "Genre-Liste & Zufall",
+    "file": "modules/panel01.html"
+  },
+  {
+    "id": "panel02",
+    "title": "Genre-Profile",
+    "file": "modules/panel02.html"
+  },
+  {
+    "id": "panel03",
+    "title": "Dashboard – Verlauf",
+    "file": "modules/panel03.html"
+  },
+  {
+    "id": "panel04",
+    "title": "Textbausteine",
+    "file": "modules/panel04.html"
+  },
+  {
+    "id": "panel05",
+    "title": "Persona-Switcher",
+    "file": "modules/panel05.html"
+  },
+  {
+    "id": "panel06",
+    "title": "Story-Sampler",
+    "file": "modules/panel06.html"
+  }
 ]

--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 [
-  {"id":"panel01","title":"Genres & Zufall","file":"modules/panel01.html"},
-  {"id":"panel02","title":"Genre-Profile","file":"modules/panel02.html"},
-  {"id":"panel03","title":"Dashboard-Log","file":"modules/panel03.html"},
-  {"id":"panel04","title":"Text-Templates","file":"modules/panel04.html"}
+  {"id":"panel01","title":"Genre-Liste & Zufall","file":"modules/panel01.html"},
+  {"id":"panel02","title":"Genre-Profile (Gewichtung)","file":"modules/panel02.html"},
+  {"id":"panel03","title":"Dashboard – Verlauf","file":"modules/panel03.html"},
+  {"id":"panel04","title":"Textbausteine","file":"modules/panel04.html"}
 ]

--- a/modules.json
+++ b/modules.json
@@ -38,5 +38,10 @@
     "id": "panel08",
     "title": "Theme-Switcher",
     "file": "modules/panel08.html"
+  },
+  {
+    "id": "panel09",
+    "title": "Einstellungen",
+    "file": "modules/panel09.html"
   }
 ]

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,6 @@
+[
+  {"id":"panel01","title":"Genres & Zufall","file":"modules/panel01.html"},
+  {"id":"panel02","title":"Genre-Profile","file":"modules/panel02.html"},
+  {"id":"panel03","title":"Dashboard-Log","file":"modules/panel03.html"},
+  {"id":"panel04","title":"Text-Templates","file":"modules/panel04.html"}
+]

--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 [
   {"id":"panel01","title":"Genre-Liste & Zufall","file":"modules/panel01.html"},
-  {"id":"panel02","title":"Genre-Profile (Gewichtung)","file":"modules/panel02.html"},
+  {"id":"panel02","title":"Genre-Profile","file":"modules/panel02.html"},
   {"id":"panel03","title":"Dashboard – Verlauf","file":"modules/panel03.html"},
   {"id":"panel04","title":"Textbausteine","file":"modules/panel04.html"}
 ]

--- a/modules.json
+++ b/modules.json
@@ -28,5 +28,10 @@
     "id": "panel06",
     "title": "Story-Sampler",
     "file": "modules/panel06.html"
+  },
+  {
+    "id": "panel07",
+    "title": "Cover-Layout",
+    "file": "modules/panel07.html"
   }
 ]

--- a/modules.json
+++ b/modules.json
@@ -2,5 +2,6 @@
   {"id":"panel01","title":"Genre-Liste & Zufall","file":"modules/panel01.html"},
   {"id":"panel02","title":"Genre-Profile","file":"modules/panel02.html"},
   {"id":"panel03","title":"Dashboard – Verlauf","file":"modules/panel03.html"},
-  {"id":"panel04","title":"Textbausteine","file":"modules/panel04.html"}
+  {"id":"panel04","title":"Textbausteine","file":"modules/panel04.html"},
+  {"id":"panel05","title":"Persona-Switcher","file":"modules/panel05.html"}
 ]

--- a/modules.json
+++ b/modules.json
@@ -33,5 +33,10 @@
     "id": "panel07",
     "title": "Cover-Layout",
     "file": "modules/panel07.html"
+  },
+  {
+    "id": "panel08",
+    "title": "Theme-Switcher",
+    "file": "modules/panel08.html"
   }
 ]

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -16,12 +16,13 @@
 <div id="panel01">
   <h2>Genres & Zufall</h2>
   <label for="genre-input">Genres (durch Kommas trennen):</label>
-  <textarea id="genre-input" aria-label="Genre-Liste"></textarea>
+  <textarea placeholder="z.B. Rock, Pop" id="genre-input" aria-label="Genre-Liste"></textarea>
   <button id="save-btn">Speichern</button>
   <button id="random-btn">Zufall</button>
   <button id="copy-btn">Kopieren</button>
   <div id="random-output" role="status" aria-live="polite"></div>
   <ul id="log"></ul>
+  <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">
 const input=document.getElementById('genre-input');
@@ -30,6 +31,7 @@ const randomBtn=document.getElementById('random-btn');
 const copyBtn=document.getElementById('copy-btn');
 const output=document.getElementById('random-output');
 const log=document.getElementById('log');
+const status=document.getElementById("status");
 const DASH_KEY='dashboardLog';
 
 function addDashboard(val){
@@ -38,23 +40,31 @@ function addDashboard(val){
   if(arr.length>10) arr.length=10;
   localStorage.setItem(DASH_KEY,JSON.stringify(arr));
 }
-
+function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent="",3000);}
 function saveList(){
-  const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
-  localStorage.setItem('genres',JSON.stringify(list));
+  const list=[...new Set(input.value.split(",").map(s=>s.trim()).filter(Boolean))];
+  try{
+    localStorage.setItem("genres",JSON.stringify(list));
+  }catch(e){
+    showStatus("Speichern fehlgeschlagen");
+  }
   return list;
 }
 function loadList(){
-  const data=localStorage.getItem('genres');
-  if(data){
-    const list=JSON.parse(data);
-    input.value=list.join(', ');
-    return list;
+  try{
+    const data=localStorage.getItem("genres");
+    if(data){
+      const list=JSON.parse(data);
+      input.value=list.join(", ");
+      return list;
+    }
+  }catch(e){
+    showStatus("Laden fehlgeschlagen");
   }
   return [];
 }
 function getList(){
-  return input.value?input.value.split(',').map(s=>s.trim()).filter(Boolean):[];
+  return input.value?input.value.split(",").map(s=>s.trim()).filter(Boolean):[];
 }
 
 saveBtn.addEventListener('click',()=>{
@@ -65,7 +75,7 @@ saveBtn.addEventListener('click',()=>{
 
 randomBtn.addEventListener('click',()=>{
   const list=getList();
-  if(list.length===0) return;
+  if(list.length===0){showStatus("Liste ist leer"); return;}
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
@@ -76,7 +86,7 @@ randomBtn.addEventListener('click',()=>{
 
 copyBtn.addEventListener('click',()=>{
   const text=output.textContent;
-  if(!text) return;
+  if(!text){showStatus("Nichts zum Kopieren"); return;}
   navigator.clipboard.writeText(text).then(()=>{
     copyBtn.style.backgroundColor='#15b57b';
     setTimeout(()=>{copyBtn.style.backgroundColor='';},800);

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <title>Panel01 – Genre-Liste & Zufall</title>
 <style>
-  #panel01 {display:grid;gap:0.5rem;max-width:320px;margin:auto;font-family:sans-serif;}
+  #panel01 {display:grid;gap:0.5rem;max-width:320px;margin:auto;font-family:var(--font-family, sans-serif);}
   #genre-input{min-height:80px;resize:vertical;}
-  button,input,textarea{font-size:1rem;border-radius:0.5rem;}
+  button,input,textarea{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
   @media(min-width:600px){#panel01{max-width:480px;}}

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -29,6 +29,14 @@ const randomBtn=document.getElementById('random-btn');
 const copyBtn=document.getElementById('copy-btn');
 const output=document.getElementById('random-output');
 const log=document.getElementById('log');
+const DASH_KEY='dashboardLog';
+
+function addDashboard(val){
+  const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
+  arr.unshift({time:new Date().toLocaleTimeString(),value:val});
+  if(arr.length>10) arr.length=10;
+  localStorage.setItem(DASH_KEY,JSON.stringify(arr));
+}
 
 function saveList(){
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
@@ -62,6 +70,7 @@ randomBtn.addEventListener('click',()=>{
   const entry=document.createElement('li');
   entry.textContent=new Date().toLocaleTimeString()+': '+choice;
   log.prepend(entry);
+  addDashboard(choice);
 });
 
 copyBtn.addEventListener('click',()=>{

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -6,7 +6,8 @@
 <style>
   #panel01 {display:grid;gap:0.5rem;max-width:320px;margin:auto;font-family:var(--font-family, sans-serif);}
   #genre-input{min-height:80px;resize:vertical;}
-  button,input,textarea{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  button,input,textarea{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
   @media(min-width:600px){#panel01{max-width:480px;}}

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Panel01 – Genres & Zufall</title>
+<title>Panel01 – Genre-Liste & Zufall</title>
 <style>
   #panel01 {display:grid;gap:0.5rem;max-width:320px;margin:auto;font-family:sans-serif;}
   #genre-input{min-height:80px;resize:vertical;}
@@ -14,7 +14,7 @@
 </head>
 <body>
 <div id="panel01">
-  <h2>Genres & Zufall</h2>
+  <h2>Genre-Liste & Zufall</h2>
   <label for="genre-input">Genres (durch Kommas trennen):</label>
   <textarea placeholder="z.B. Rock, Pop" id="genre-input" aria-label="Genre-Liste"></textarea>
   <button id="save-btn">Speichern</button>

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -5,7 +5,8 @@
 <title>Panel01 – Genres & Zufall</title>
 <style>
   #panel01 {display:grid;gap:0.5rem;max-width:320px;margin:auto;font-family:sans-serif;}
-  #genre-input{min-height:80px;}
+  #genre-input{min-height:80px;resize:vertical;}
+  button,input,textarea{font-size:1rem;border-radius:0.5rem;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
   @media(min-width:600px){#panel01{max-width:480px;}}

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -8,7 +8,8 @@
   #genre-input{min-height:80px;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
-  select,button,textarea,input{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  select,button,textarea,input{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   textarea{resize:vertical;}
   @media(min-width:600px){#panel02{max-width:520px;}}
 </style>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -18,6 +18,8 @@
   <h2>Genre-Profile</h2>
   <label for="profile-name">Profilname:</label>
   <input id="profile-name" aria-label="Profilname">
+  <label for="profile-weight">Gewichtung:</label>
+  <input id="profile-weight" type="number" min="1" max="10" value="1" aria-label="Gewichtung">
   <button id="add-profile-btn">Profil speichern</button>
   <label for="profile-select">Profil wählen:</label>
   <select id="profile-select"></select>
@@ -31,6 +33,7 @@
 </div>
 <script type="module">
 const nameInput=document.getElementById('profile-name');
+const weightInput=document.getElementById('profile-weight');
 const addBtn=document.getElementById('add-profile-btn');
 const select=document.getElementById('profile-select');
 const input=document.getElementById('genre-input');
@@ -50,7 +53,17 @@ function addDashboard(val){
 
 function loadProfiles(){
   const data=localStorage.getItem('genreProfiles');
-  return data?JSON.parse(data):{};
+  const raw=data?JSON.parse(data):{};
+  const out={};
+  Object.entries(raw).forEach(([name,val])=>{
+    if(Array.isArray(val)){
+      out[name]={list:val,weight:1};
+    }else{
+      out[name]=val;
+      if(!out[name].weight) out[name].weight=1;
+    }
+  });
+  return out;
 }
 
 function saveProfiles(profiles){
@@ -66,13 +79,26 @@ function refreshSelect(profiles){
   });
 }
 
+function weightedRandom(profiles){
+  const entries=Object.values(profiles);
+  const total=entries.reduce((sum,p)=>sum+(p.weight||1),0);
+  let r=Math.random()*total;
+  for(const p of entries){
+    r-=p.weight||1;
+    if(r<=0) return p.list;
+  }
+  return entries[0]?.list||[];
+}
+
 function loadCurrentList(){
   const profiles=loadProfiles();
   const cur=select.value;
   if(cur&&profiles[cur]){
-    input.value=profiles[cur].join(', ');
+    input.value=profiles[cur].list.join(', ');
+    weightInput.value=profiles[cur].weight||1;
   } else {
     input.value='';
+    weightInput.value='1';
   }
 }
 
@@ -80,8 +106,9 @@ addBtn.addEventListener('click',()=>{
   const name=nameInput.value.trim();
   if(!name) return;
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  const weight=Number(weightInput.value)||1;
   const profiles=loadProfiles();
-  profiles[name]=list;
+  profiles[name]={list,weight};
   saveProfiles(profiles);
   refreshSelect(profiles);
   select.value=name;
@@ -91,7 +118,9 @@ saveBtn.addEventListener('click',()=>{
   const name=select.value;
   if(!name) return;
   const profiles=loadProfiles();
-  profiles[name]=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  const weight=Number(weightInput.value)||1;
+  profiles[name]={list,weight};
   saveProfiles(profiles);
   saveBtn.classList.add('saved');
   setTimeout(()=>saveBtn.classList.remove('saved'),500);
@@ -100,7 +129,8 @@ saveBtn.addEventListener('click',()=>{
 select.addEventListener('change',loadCurrentList);
 
 randomBtn.addEventListener('click',()=>{
-  const list=input.value.split(',').map(s=>s.trim()).filter(Boolean);
+  const profiles=loadProfiles();
+  const list=weightedRandom(profiles);
   if(list.length===0) return;
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel02 – Genre-Profile</title>
+<style>
+  #panel02{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #genre-input{min-height:80px;}
+  #random-output{font-weight:bold;margin-top:0.5rem;}
+  #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
+  select,button,textarea,input{font-size:1rem;}
+  @media(min-width:600px){#panel02{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel02">
+  <h2>Genre-Profile</h2>
+  <label for="profile-name">Profilname:</label>
+  <input id="profile-name" aria-label="Profilname">
+  <button id="add-profile-btn">Profil speichern</button>
+  <label for="profile-select">Profil wählen:</label>
+  <select id="profile-select"></select>
+  <label for="genre-input">Genres (mit Komma trennen):</label>
+  <textarea id="genre-input" aria-label="Genre-Liste"></textarea>
+  <button id="save-btn">Liste sichern</button>
+  <button id="random-btn">Zufall</button>
+  <button id="copy-btn">Kopieren</button>
+  <div id="random-output" role="status" aria-live="polite"></div>
+  <ul id="log"></ul>
+</div>
+<script type="module">
+const nameInput=document.getElementById('profile-name');
+const addBtn=document.getElementById('add-profile-btn');
+const select=document.getElementById('profile-select');
+const input=document.getElementById('genre-input');
+const saveBtn=document.getElementById('save-btn');
+const randomBtn=document.getElementById('random-btn');
+const copyBtn=document.getElementById('copy-btn');
+const output=document.getElementById('random-output');
+const log=document.getElementById('log');
+
+function loadProfiles(){
+  const data=localStorage.getItem('genreProfiles');
+  return data?JSON.parse(data):{};
+}
+
+function saveProfiles(profiles){
+  localStorage.setItem('genreProfiles',JSON.stringify(profiles));
+}
+
+function refreshSelect(profiles){
+  select.innerHTML='';
+  Object.keys(profiles).forEach(name=>{
+    const opt=document.createElement('option');
+    opt.value=name; opt.textContent=name;
+    select.appendChild(opt);
+  });
+}
+
+function loadCurrentList(){
+  const profiles=loadProfiles();
+  const cur=select.value;
+  if(cur&&profiles[cur]){
+    input.value=profiles[cur].join(', ');
+  } else {
+    input.value='';
+  }
+}
+
+addBtn.addEventListener('click',()=>{
+  const name=nameInput.value.trim();
+  if(!name) return;
+  const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  const profiles=loadProfiles();
+  profiles[name]=list;
+  saveProfiles(profiles);
+  refreshSelect(profiles);
+  select.value=name;
+});
+
+saveBtn.addEventListener('click',()=>{
+  const name=select.value;
+  if(!name) return;
+  const profiles=loadProfiles();
+  profiles[name]=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  saveProfiles(profiles);
+  saveBtn.classList.add('saved');
+  setTimeout(()=>saveBtn.classList.remove('saved'),500);
+});
+
+select.addEventListener('change',loadCurrentList);
+
+randomBtn.addEventListener('click',()=>{
+  const list=input.value.split(',').map(s=>s.trim()).filter(Boolean);
+  if(list.length===0) return;
+  const choice=list[Math.floor(Math.random()*list.length)];
+  output.textContent=choice;
+  const entry=document.createElement('li');
+  entry.textContent=new Date().toLocaleTimeString()+': '+choice;
+  log.prepend(entry);
+});
+
+copyBtn.addEventListener('click',()=>{
+  const text=output.textContent;
+  if(!text) return;
+  navigator.clipboard.writeText(text).then(()=>{
+    copyBtn.style.backgroundColor='#15b57b';
+    setTimeout(()=>{copyBtn.style.backgroundColor='';},800);
+  });
+});
+
+// init
+refreshSelect(loadProfiles());
+loadCurrentList();
+</script>
+</body>
+</html>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -18,6 +18,8 @@
   <h2>Genre-Profile</h2>
   <label for="profile-name">Profilname:</label>
   <input id="profile-name" placeholder="Mein Profil" aria-label="Profilname">
+  <label for="weight-input">Gewichtung:</label>
+  <input type="number" id="weight-input" value="1" min="1" aria-label="Gewichtung">
   <button id="add-profile-btn">Profil speichern</button>
   <label for="profile-select">Profil wählen:</label>
   <select id="profile-select"></select>
@@ -25,6 +27,7 @@
   <textarea id="genre-input" placeholder="z.B. Funk, Jazz" aria-label="Genre-Liste"></textarea>
   <button id="save-btn">Liste sichern</button>
   <button id="random-btn">Zufall</button>
+  <button id="weighted-btn">Gewichteter Zufall</button>
   <button id="copy-btn">Kopieren</button>
   <div id="random-output" role="status" aria-live="polite"></div>
   <ul id="log"></ul>
@@ -35,8 +38,10 @@ const nameInput=document.getElementById('profile-name');
 const addBtn=document.getElementById('add-profile-btn');
 const select=document.getElementById('profile-select');
 const input=document.getElementById('genre-input');
+const weightInput=document.getElementById('weight-input');
 const saveBtn=document.getElementById('save-btn');
 const randomBtn=document.getElementById('random-btn');
+const weightedBtn=document.getElementById('weighted-btn');
 const copyBtn=document.getElementById('copy-btn');
 const output=document.getElementById('random-output');
 const log=document.getElementById('log');
@@ -54,7 +59,12 @@ function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textConten
 
 function loadProfiles(){
   try{
-    return JSON.parse(localStorage.getItem('genreProfiles'))||{};
+    const obj=JSON.parse(localStorage.getItem('genreProfiles'))||{};
+    Object.keys(obj).forEach(k=>{
+      if(Array.isArray(obj[k])) obj[k]={list:obj[k],weight:1};
+      else obj[k].weight=parseInt(obj[k].weight)||1;
+    });
+    return obj;
   }catch(e){
     showStatus('Speicher defekt');
     return {};
@@ -80,9 +90,11 @@ function loadCurrentList(){
   const profiles=loadProfiles();
   const cur=select.value;
   if(cur && profiles[cur]){
-    input.value=profiles[cur].join(', ');
+    input.value=profiles[cur].list.join(', ');
+    weightInput.value=profiles[cur].weight;
   }else{
     input.value='';
+    weightInput.value='1';
   }
 }
 
@@ -91,7 +103,7 @@ addBtn.addEventListener('click',()=>{
   if(!name){showStatus('Name fehlt'); return;}
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
   const profiles=loadProfiles();
-  profiles[name]=list;
+  profiles[name]={list,weight:parseInt(weightInput.value)||1};
   saveProfiles(profiles);
   refreshSelect(profiles);
   select.value=name;
@@ -102,7 +114,7 @@ saveBtn.addEventListener('click',()=>{
   const name=select.value;
   if(!name){showStatus('Profil wählen'); return;}
   const profiles=loadProfiles();
-  profiles[name]=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
+  profiles[name]={list:[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))],weight:parseInt(weightInput.value)||1};
   saveProfiles(profiles);
   saveBtn.classList.add('saved');
   setTimeout(()=>saveBtn.classList.remove('saved'),500);
@@ -113,13 +125,34 @@ select.addEventListener('change',loadCurrentList);
 
 randomBtn.addEventListener('click',()=>{
   const profiles=loadProfiles();
-  const list=profiles[select.value]||[];
+  const list=(profiles[select.value]||{}).list||[];
   if(list.length===0){showStatus('Keine Genres vorhanden'); return;}
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
   entry.textContent=new Date().toLocaleTimeString()+': '+choice;
   log.prepend(entry);
+  addDashboard(choice);
+});
+
+weightedBtn.addEventListener('click',()=>{
+  const profiles=loadProfiles();
+  const names=Object.keys(profiles);
+  if(names.length===0){showStatus('Keine Profile');return;}
+  const total=names.reduce((s,n)=>s+(profiles[n].weight||1),0);
+  let r=Math.random()*total;
+  let picked=names[0];
+  for(const n of names){
+    r-=profiles[n].weight||1;
+    if(r<=0){picked=n;break;}
+  }
+  const list=profiles[picked].list;
+  if(list.length===0){showStatus('Profil leer');return;}
+  const choice=list[Math.floor(Math.random()*list.length)];
+  output.textContent=choice;
+  const li=document.createElement('li');
+  li.textContent=new Date().toLocaleTimeString()+': '+choice+' ('+picked+')';
+  log.prepend(li);
   addDashboard(choice);
 });
 

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <title>Panel02 – Genre-Profile</title>
 <style>
-  #panel02{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #panel02{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   #genre-input{min-height:80px;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
-  select,button,textarea,input{font-size:1rem;border-radius:0.5rem;}
+  select,button,textarea,input{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   textarea{resize:vertical;}
   @media(min-width:600px){#panel02{max-width:520px;}}
 </style>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -38,6 +38,14 @@ const randomBtn=document.getElementById('random-btn');
 const copyBtn=document.getElementById('copy-btn');
 const output=document.getElementById('random-output');
 const log=document.getElementById('log');
+const DASH_KEY='dashboardLog';
+
+function addDashboard(val){
+  const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
+  arr.unshift({time:new Date().toLocaleTimeString(),value:val});
+  if(arr.length>10) arr.length=10;
+  localStorage.setItem(DASH_KEY,JSON.stringify(arr));
+}
 
 function loadProfiles(){
   const data=localStorage.getItem('genreProfiles');
@@ -98,6 +106,7 @@ randomBtn.addEventListener('click',()=>{
   const entry=document.createElement('li');
   entry.textContent=new Date().toLocaleTimeString()+': '+choice;
   log.prepend(entry);
+  addDashboard(choice);
 });
 
 copyBtn.addEventListener('click',()=>{

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -8,7 +8,8 @@
   #genre-input{min-height:80px;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
-  select,button,textarea,input{font-size:1rem;}
+  select,button,textarea,input{font-size:1rem;border-radius:0.5rem;}
+  textarea{resize:vertical;}
   @media(min-width:600px){#panel02{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Panel02 – Genre-Profile (Gewichtung)</title>
+<title>Panel02 – Genre-Profile</title>
 <style>
   #panel02{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
   #genre-input{min-height:80px;}
@@ -15,11 +15,9 @@
 </head>
 <body>
 <div id="panel02">
-  <h2>Genre-Profile (Gewichtung)</h2>
+  <h2>Genre-Profile</h2>
   <label for="profile-name">Profilname:</label>
   <input id="profile-name" placeholder="Mein Profil" aria-label="Profilname">
-  <label for="profile-weight">Gewichtung:</label>
-  <input id="profile-weight" type="number" min="1" max="10" value="1" aria-label="Gewichtung">
   <button id="add-profile-btn">Profil speichern</button>
   <label for="profile-select">Profil wählen:</label>
   <select id="profile-select"></select>
@@ -34,7 +32,6 @@
 </div>
 <script type="module">
 const nameInput=document.getElementById('profile-name');
-const weightInput=document.getElementById('profile-weight');
 const addBtn=document.getElementById('add-profile-btn');
 const select=document.getElementById('profile-select');
 const input=document.getElementById('genre-input');
@@ -43,38 +40,31 @@ const randomBtn=document.getElementById('random-btn');
 const copyBtn=document.getElementById('copy-btn');
 const output=document.getElementById('random-output');
 const log=document.getElementById('log');
+const status=document.getElementById('status');
 const DASH_KEY='dashboardLog';
 
-const status=document.getElementById("status");
 function addDashboard(val){
   const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
   arr.unshift({time:new Date().toLocaleTimeString(),value:val});
   if(arr.length>10) arr.length=10;
   localStorage.setItem(DASH_KEY,JSON.stringify(arr));
 }
+
 function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent="",3000);}
 
 function loadProfiles(){
-  const data=localStorage.getItem("genreProfiles");
-  let raw={};
-  try{raw=data?JSON.parse(data):{};}catch(e){showStatus("Speicher defekt");}
-  const out={};
-  Object.entries(raw).forEach(([name,val])=>{
-    if(Array.isArray(val)){
-      out[name]={list:val,weight:1};
-    }else{
-      out[name]=val;
-      if(!out[name].weight) out[name].weight=1;
-    }
-  });
-  return out;
+  try{
+    return JSON.parse(localStorage.getItem('genreProfiles'))||{};
+  }catch(e){
+    showStatus('Speicher defekt');
+    return {};
+  }
 }
+
 function saveProfiles(profiles){
   try{
-    localStorage.setItem("genreProfiles",JSON.stringify(profiles));
-  }catch(e){
-    showStatus("Speichern fehlgeschlagen");
-  }
+    localStorage.setItem('genreProfiles',JSON.stringify(profiles));
+  }catch(e){showStatus('Speichern fehlgeschlagen');}
 }
 
 function refreshSelect(profiles){
@@ -86,60 +76,45 @@ function refreshSelect(profiles){
   });
 }
 
-function weightedRandom(profiles){
-  const entries=Object.values(profiles);
-  const total=entries.reduce((sum,p)=>sum+(p.weight||1),0);
-  let r=Math.random()*total;
-  for(const p of entries){
-    r-=p.weight||1;
-    if(r<=0) return p.list;
-  }
-  return entries[0]?.list||[];
-}
-
 function loadCurrentList(){
   const profiles=loadProfiles();
   const cur=select.value;
-  if(cur&&profiles[cur]){
-    input.value=profiles[cur].list.join(', ');
-    weightInput.value=profiles[cur].weight||1;
-  } else {
+  if(cur && profiles[cur]){
+    input.value=profiles[cur].join(', ');
+  }else{
     input.value='';
-    weightInput.value='1';
   }
 }
 
 addBtn.addEventListener('click',()=>{
   const name=nameInput.value.trim();
-  if(!name){showStatus("Name fehlt"); return;}
+  if(!name){showStatus('Name fehlt'); return;}
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
-  const weight=Number(weightInput.value)||1;
   const profiles=loadProfiles();
-  profiles[name]={list,weight};
+  profiles[name]=list;
   saveProfiles(profiles);
   refreshSelect(profiles);
   select.value=name;
-showStatus("Profil gespeichert");
+  showStatus('Profil gespeichert');
 });
 
 saveBtn.addEventListener('click',()=>{
   const name=select.value;
-  if(!name){showStatus("Profil wählen"); return;}
+  if(!name){showStatus('Profil wählen'); return;}
   const profiles=loadProfiles();
-  const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
-  const weight=Number(weightInput.value)||1;
-  profiles[name]={list,weight};
+  profiles[name]=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
   saveProfiles(profiles);
   saveBtn.classList.add('saved');
   setTimeout(()=>saveBtn.classList.remove('saved'),500);
-showStatus("Liste gespeichert");
+  showStatus('Liste gespeichert');
 });
 
 select.addEventListener('change',loadCurrentList);
+
 randomBtn.addEventListener('click',()=>{
   const profiles=loadProfiles();
-  const list=weightedRandom(profiles);
-  if(list.length===0){showStatus("Keine Genres vorhanden"); return;}
+  const list=profiles[select.value]||[];
+  if(list.length===0){showStatus('Keine Genres vorhanden'); return;}
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
@@ -150,7 +125,7 @@ randomBtn.addEventListener('click',()=>{
 
 copyBtn.addEventListener('click',()=>{
   const text=output.textContent;
-  if(!text){showStatus("Nichts zum Kopieren"); return;}
+  if(!text){showStatus('Nichts zum Kopieren'); return;}
   navigator.clipboard.writeText(text).then(()=>{
     copyBtn.style.backgroundColor='#15b57b';
     setTimeout(()=>{copyBtn.style.backgroundColor='';},800);

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Panel02 – Genre-Profile</title>
+<title>Panel02 – Genre-Profile (Gewichtung)</title>
 <style>
   #panel02{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
   #genre-input{min-height:80px;}
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id="panel02">
-  <h2>Genre-Profile</h2>
+  <h2>Genre-Profile (Gewichtung)</h2>
   <label for="profile-name">Profilname:</label>
   <input id="profile-name" placeholder="Mein Profil" aria-label="Profilname">
   <label for="profile-weight">Gewichtung:</label>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -17,19 +17,20 @@
 <div id="panel02">
   <h2>Genre-Profile</h2>
   <label for="profile-name">Profilname:</label>
-  <input id="profile-name" aria-label="Profilname">
+  <input id="profile-name" placeholder="Mein Profil" aria-label="Profilname">
   <label for="profile-weight">Gewichtung:</label>
   <input id="profile-weight" type="number" min="1" max="10" value="1" aria-label="Gewichtung">
   <button id="add-profile-btn">Profil speichern</button>
   <label for="profile-select">Profil wählen:</label>
   <select id="profile-select"></select>
   <label for="genre-input">Genres (mit Komma trennen):</label>
-  <textarea id="genre-input" aria-label="Genre-Liste"></textarea>
+  <textarea id="genre-input" placeholder="z.B. Funk, Jazz" aria-label="Genre-Liste"></textarea>
   <button id="save-btn">Liste sichern</button>
   <button id="random-btn">Zufall</button>
   <button id="copy-btn">Kopieren</button>
   <div id="random-output" role="status" aria-live="polite"></div>
   <ul id="log"></ul>
+  <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">
 const nameInput=document.getElementById('profile-name');
@@ -44,16 +45,19 @@ const output=document.getElementById('random-output');
 const log=document.getElementById('log');
 const DASH_KEY='dashboardLog';
 
+const status=document.getElementById("status");
 function addDashboard(val){
   const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
   arr.unshift({time:new Date().toLocaleTimeString(),value:val});
   if(arr.length>10) arr.length=10;
   localStorage.setItem(DASH_KEY,JSON.stringify(arr));
 }
+function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent="",3000);}
 
 function loadProfiles(){
-  const data=localStorage.getItem('genreProfiles');
-  const raw=data?JSON.parse(data):{};
+  const data=localStorage.getItem("genreProfiles");
+  let raw={};
+  try{raw=data?JSON.parse(data):{};}catch(e){showStatus("Speicher defekt");}
   const out={};
   Object.entries(raw).forEach(([name,val])=>{
     if(Array.isArray(val)){
@@ -65,9 +69,12 @@ function loadProfiles(){
   });
   return out;
 }
-
 function saveProfiles(profiles){
-  localStorage.setItem('genreProfiles',JSON.stringify(profiles));
+  try{
+    localStorage.setItem("genreProfiles",JSON.stringify(profiles));
+  }catch(e){
+    showStatus("Speichern fehlgeschlagen");
+  }
 }
 
 function refreshSelect(profiles){
@@ -104,7 +111,7 @@ function loadCurrentList(){
 
 addBtn.addEventListener('click',()=>{
   const name=nameInput.value.trim();
-  if(!name) return;
+  if(!name){showStatus("Name fehlt"); return;}
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
   const weight=Number(weightInput.value)||1;
   const profiles=loadProfiles();
@@ -112,11 +119,12 @@ addBtn.addEventListener('click',()=>{
   saveProfiles(profiles);
   refreshSelect(profiles);
   select.value=name;
+showStatus("Profil gespeichert");
 });
 
 saveBtn.addEventListener('click',()=>{
   const name=select.value;
-  if(!name) return;
+  if(!name){showStatus("Profil wählen"); return;}
   const profiles=loadProfiles();
   const list=[...new Set(input.value.split(',').map(s=>s.trim()).filter(Boolean))];
   const weight=Number(weightInput.value)||1;
@@ -124,14 +132,14 @@ saveBtn.addEventListener('click',()=>{
   saveProfiles(profiles);
   saveBtn.classList.add('saved');
   setTimeout(()=>saveBtn.classList.remove('saved'),500);
+showStatus("Liste gespeichert");
 });
 
 select.addEventListener('change',loadCurrentList);
-
 randomBtn.addEventListener('click',()=>{
   const profiles=loadProfiles();
   const list=weightedRandom(profiles);
-  if(list.length===0) return;
+  if(list.length===0){showStatus("Keine Genres vorhanden"); return;}
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
@@ -142,7 +150,7 @@ randomBtn.addEventListener('click',()=>{
 
 copyBtn.addEventListener('click',()=>{
   const text=output.textContent;
-  if(!text) return;
+  if(!text){showStatus("Nichts zum Kopieren"); return;}
   navigator.clipboard.writeText(text).then(()=>{
     copyBtn.style.backgroundColor='#15b57b';
     setTimeout(()=>{copyBtn.style.backgroundColor='';},800);

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Panel03 – Dashboard</title>
+<title>Panel03 – Dashboard: Verlauf</title>
 <style>
   #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
   #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div id="panel03">
-  <h2>Dashboard-Log</h2>
+  <h2>Dashboard – Verlauf</h2>
   <ul id="log-list"></ul>
   <button id="clear-btn">Alles löschen</button>
 </div>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel03 – Dashboard</title>
+<style>
+  #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
+  @media(min-width:600px){#panel03{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel03">
+  <h2>Dashboard-Log</h2>
+  <ul id="log-list"></ul>
+  <button id="clear-btn">Alles löschen</button>
+</div>
+<script type="module">
+const STORAGE_KEY='dashboardLog';
+const list=document.getElementById('log-list');
+const clearBtn=document.getElementById('clear-btn');
+function loadLog(){
+  const data=localStorage.getItem(STORAGE_KEY);
+  return data?JSON.parse(data):[];
+}
+function saveLog(entries){
+  localStorage.setItem(STORAGE_KEY,JSON.stringify(entries));
+}
+function render(){
+  const entries=loadLog();
+  list.innerHTML='';
+  entries.forEach(e=>{
+    const li=document.createElement('li');
+    li.textContent=`${e.time}: ${e.value}`;
+    list.appendChild(li);
+  });
+}
+clearBtn.addEventListener('click',()=>{
+  if(!confirm('Wirklich alles löschen?')) return;
+  localStorage.removeItem(STORAGE_KEY);
+  render();
+});
+render();
+</script>
+</body>
+</html>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -6,6 +6,7 @@
 <style>
   #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
   #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
+  button{font-size:1rem;border-radius:0.5rem;}
   @media(min-width:600px){#panel03{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -6,7 +6,8 @@
 <style>
   #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
-  button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   @media(min-width:600px){#panel03{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <title>Panel03 – Dashboard: Verlauf</title>
 <style>
-  #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
-  button{font-size:1rem;border-radius:0.5rem;}
+  button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   @media(min-width:600px){#panel03{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Panel04 – Text-Templates</title>
+<title>Panel04 – Textbausteine</title>
 <style>
   #panel04{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
   #template-list{display:flex;flex-direction:column;gap:0.4rem;}
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id="panel04">
-  <h2>Text-Templates</h2>
+  <h2>Textbausteine</h2>
   <label for="title-input">Titel:</label>
   <input id="title-input" aria-label="Template-Titel">
   <label for="text-input">Text:</label>

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -6,9 +6,10 @@
 <style>
   #panel04{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   #template-list{display:flex;flex-direction:column;gap:0.4rem;}
-  .tmpl-btn{background:#338a5d;color:#fff;border:none;border-radius:var(--btn-radius,0.8rem);padding:0.4rem 0.8rem;font-size:var(--base-font,1rem);cursor:pointer;display:inline-flex;align-items:center;gap:0.5rem;}
+  .tmpl-btn{background:#338a5d;color:#fff;border:none;border-radius:var(--btn-radius,0.8rem);padding:0.4rem 0.8rem;font-size:var(--base-font,1rem);cursor:pointer;display:inline-flex;align-items:center;gap:0.5rem;line-height:1.4;}
   .remove-btn{background:#db3665;border-radius:var(--btn-radius,0.8rem);color:#fff;padding:0.3rem 0.6rem;border:none;cursor:pointer;}
-  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   @media(min-width:600px){#panel04{max-width:520px;}}
   textarea{resize:vertical;min-height:80px;}
 </style>

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <title>Panel04 – Textbausteine</title>
 <style>
-  #panel04{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #panel04{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   #template-list{display:flex;flex-direction:column;gap:0.4rem;}
-  .tmpl-btn{background:#338a5d;color:#fff;border:none;border-radius:0.8rem;padding:0.4rem 0.8rem;font-size:1rem;cursor:pointer;display:inline-flex;align-items:center;gap:0.5rem;}
-  .remove-btn{background:#db3665;border-radius:0.8rem;color:#fff;padding:0.3rem 0.6rem;border:none;cursor:pointer;}
-  input,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  .tmpl-btn{background:#338a5d;color:#fff;border:none;border-radius:var(--btn-radius,0.8rem);padding:0.4rem 0.8rem;font-size:var(--base-font,1rem);cursor:pointer;display:inline-flex;align-items:center;gap:0.5rem;}
+  .remove-btn{background:#db3665;border-radius:var(--btn-radius,0.8rem);color:#fff;padding:0.3rem 0.6rem;border:none;cursor:pointer;}
+  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   @media(min-width:600px){#panel04{max-width:520px;}}
   textarea{resize:vertical;min-height:80px;}
 </style>

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel04 – Text-Templates</title>
+<style>
+  #panel04{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #template-list{display:flex;flex-direction:column;gap:0.4rem;}
+  .tmpl-btn{background:#338a5d;color:#fff;border:none;border-radius:0.8rem;padding:0.4rem 0.8rem;font-size:1rem;cursor:pointer;display:inline-flex;align-items:center;gap:0.5rem;}
+  .remove-btn{background:#db3665;border-radius:0.8rem;color:#fff;padding:0.3rem 0.6rem;border:none;cursor:pointer;}
+  input,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  @media(min-width:600px){#panel04{max-width:520px;}}
+  textarea{resize:vertical;min-height:80px;}
+</style>
+</head>
+<body>
+<div id="panel04">
+  <h2>Text-Templates</h2>
+  <label for="title-input">Titel:</label>
+  <input id="title-input" aria-label="Template-Titel">
+  <label for="text-input">Text:</label>
+  <textarea id="text-input" aria-label="Template-Text"></textarea>
+  <button id="add-btn">Hinzufügen</button>
+  <div id="template-list"></div>
+</div>
+<script type="module">
+const titleInput=document.getElementById('title-input');
+const textInput=document.getElementById('text-input');
+const addBtn=document.getElementById('add-btn');
+const listDiv=document.getElementById('template-list');
+const STORE_KEY='templates';
+
+function loadTemplates(){
+  const data=localStorage.getItem(STORE_KEY);
+  return data?JSON.parse(data):[];
+}
+function saveTemplates(arr){
+  localStorage.setItem(STORE_KEY,JSON.stringify(arr));
+}
+function render(){
+  const arr=loadTemplates();
+  listDiv.innerHTML='';
+  arr.forEach((t,i)=>{
+    const btn=document.createElement('button');
+    btn.className='tmpl-btn';
+    btn.textContent=t.title;
+    btn.onclick=()=>{navigator.clipboard.writeText(t.text);};
+    const rm=document.createElement('button');
+    rm.className='remove-btn';
+    rm.textContent='✖';
+    rm.onclick=()=>{arr.splice(i,1);saveTemplates(arr);render();};
+    const wrapper=document.createElement('div');
+    wrapper.appendChild(btn);wrapper.appendChild(rm);
+    listDiv.appendChild(wrapper);
+  });
+}
+addBtn.addEventListener('click',()=>{
+  const title=titleInput.value.trim();
+  const text=textInput.value.trim();
+  if(!title||!text) return;
+  const arr=loadTemplates();
+  arr.push({title,text});
+  saveTemplates(arr);
+  titleInput.value='';textInput.value='';
+  render();
+});
+render();
+</script>
+</body>
+</html>

--- a/modules/panel05.html
+++ b/modules/panel05.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <title>Panel05 – Persona-Switcher</title>
 <style>
-  #panel05{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #panel05{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   textarea{min-height:80px;resize:vertical;}
-  input,select,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  input,select,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   @media(min-width:600px){#panel05{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel05.html
+++ b/modules/panel05.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel05 – Persona-Switcher</title>
+<style>
+  #panel05{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  textarea{min-height:80px;resize:vertical;}
+  input,select,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  @media(min-width:600px){#panel05{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel05">
+  <h2>Persona-Switcher</h2>
+  <label for="persona-name">Name:</label>
+  <input id="persona-name" aria-label="Persona-Name">
+  <label for="persona-desc">Beschreibung:</label>
+  <textarea id="persona-desc" aria-label="Persona-Beschreibung"></textarea>
+  <button id="add-btn">Profil speichern</button>
+  <label for="persona-select">Profil wählen:</label>
+  <select id="persona-select"></select>
+  <button id="copy-btn">Kopieren</button>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+const nameInput=document.getElementById('persona-name');
+const descInput=document.getElementById('persona-desc');
+const addBtn=document.getElementById('add-btn');
+const select=document.getElementById('persona-select');
+const copyBtn=document.getElementById('copy-btn');
+const status=document.getElementById('status');
+const STORE_KEY='personas';
+
+function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent='',3000);}
+function load(){
+  try{return JSON.parse(localStorage.getItem(STORE_KEY))||{};}catch(e){showStatus('Speicherfehler');return {};}
+}
+function save(obj){
+  try{localStorage.setItem(STORE_KEY,JSON.stringify(obj));}catch(e){showStatus('Speichern fehlgeschlagen');}
+}
+function refreshSelect(obj){
+  select.innerHTML='';
+  Object.keys(obj).forEach(name=>{
+    const opt=document.createElement('option');
+    opt.value=name;opt.textContent=name;select.appendChild(opt);
+  });
+}
+function loadCurrent(){
+  const obj=load();
+  const cur=obj[select.value];
+  descInput.value=cur?cur.desc:'';
+}
+addBtn.addEventListener('click',()=>{
+  const name=nameInput.value.trim();
+  const desc=descInput.value.trim();
+  if(!name||!desc){showStatus('Name oder Beschreibung fehlt');return;}
+  const obj=load();
+  obj[name]={desc};
+  save(obj);
+  refreshSelect(obj);
+  select.value=name;
+  showStatus('Profil gespeichert');
+});
+select.addEventListener('change',loadCurrent);
+copyBtn.addEventListener('click',()=>{
+  const text=descInput.value.trim();
+  if(!text){showStatus('Nichts zum Kopieren');return;}
+  navigator.clipboard.writeText(text).then(()=>{
+    copyBtn.style.backgroundColor='#15b57b';
+    setTimeout(()=>{copyBtn.style.backgroundColor='';},800);
+  });
+});
+refreshSelect(load());
+loadCurrent();
+</script>
+</body>
+</html>

--- a/modules/panel05.html
+++ b/modules/panel05.html
@@ -6,7 +6,8 @@
 <style>
   #panel05{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   textarea{min-height:80px;resize:vertical;}
-  input,select,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  input,select,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   @media(min-width:600px){#panel05{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel06.html
+++ b/modules/panel06.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <title>Panel06 – Story-Sampler</title>
 <style>
-  #panel06{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  #panel06{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   textarea{min-height:100px;resize:vertical;}
-  input,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
   @media(min-width:600px){#panel06{max-width:520px;}}

--- a/modules/panel06.html
+++ b/modules/panel06.html
@@ -6,7 +6,8 @@
 <style>
   #panel06{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
   textarea{min-height:100px;resize:vertical;}
-  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  input,textarea,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   #random-output{font-weight:bold;margin-top:0.5rem;}
   #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
   @media(min-width:600px){#panel06{max-width:520px;}}

--- a/modules/panel06.html
+++ b/modules/panel06.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel06 – Story-Sampler</title>
+<style>
+  #panel06{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  textarea{min-height:100px;resize:vertical;}
+  input,textarea,button{font-size:1rem;border-radius:0.5rem;}
+  #random-output{font-weight:bold;margin-top:0.5rem;}
+  #log{max-height:100px;overflow-y:auto;padding-left:1rem;}
+  @media(min-width:600px){#panel06{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel06">
+  <h2>Story-Sampler</h2>
+  <label for="story-input">Story-Ideen (je Zeile eine):</label>
+  <textarea id="story-input" aria-label="Story-Ideen"></textarea>
+  <button id="save-btn">Speichern</button>
+  <button id="random-btn">Zufall</button>
+  <button id="copy-btn">Kopieren</button>
+  <div id="random-output" role="status" aria-live="polite"></div>
+  <ul id="log"></ul>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+const input=document.getElementById('story-input');
+const saveBtn=document.getElementById('save-btn');
+const randomBtn=document.getElementById('random-btn');
+const copyBtn=document.getElementById('copy-btn');
+const output=document.getElementById('random-output');
+const log=document.getElementById('log');
+const status=document.getElementById('status');
+const STORE_KEY='storySampler';
+const DASH_KEY='dashboardLog';
+function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent='',3000);}
+function loadList(){try{return JSON.parse(localStorage.getItem(STORE_KEY))||[];}catch(e){showStatus('Laden fehlgeschlagen');return [];}}
+function saveList(list){try{localStorage.setItem(STORE_KEY,JSON.stringify(list));}catch(e){showStatus('Speichern fehlgeschlagen');}}
+function addDashboard(val){const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');arr.unshift({time:new Date().toLocaleTimeString(),value:val});if(arr.length>10) arr.length=10;localStorage.setItem(DASH_KEY,JSON.stringify(arr));}
+function render(){const list=loadList();input.value=list.join('\n');}
+saveBtn.addEventListener('click',()=>{const list=input.value.split('\n').map(s=>s.trim()).filter(Boolean);saveList(list);showStatus('Gespeichert');});
+randomBtn.addEventListener('click',()=>{const list=input.value.split('\n').map(s=>s.trim()).filter(Boolean);if(list.length===0){showStatus('Keine Einträge');return;}const choice=list[Math.floor(Math.random()*list.length)];output.textContent=choice;const li=document.createElement('li');li.textContent=new Date().toLocaleTimeString()+': '+choice;log.prepend(li);addDashboard(choice);});
+copyBtn.addEventListener('click',()=>{const text=output.textContent;if(!text){showStatus('Nichts zum Kopieren');return;}navigator.clipboard.writeText(text).then(()=>{copyBtn.style.backgroundColor='#15b57b';setTimeout(()=>{copyBtn.style.backgroundColor='';},800);});});
+render();
+</script>
+</body>
+</html>

--- a/modules/panel07.html
+++ b/modules/panel07.html
@@ -5,7 +5,8 @@
 <title>Panel07 – Cover-Layout</title>
 <style>
   #panel07{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
-  input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   #preview{height:120px;display:flex;align-items:center;justify-content:center;border:1px solid #ccc;}
   @media(min-width:600px){#panel07{max-width:520px;}}
 </style>

--- a/modules/panel07.html
+++ b/modules/panel07.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel07 – Cover-Layout</title>
+<style>
+  #panel07{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  input,button{font-size:1rem;border-radius:0.5rem;}
+  #preview{height:120px;display:flex;align-items:center;justify-content:center;border:1px solid #ccc;}
+  @media(min-width:600px){#panel07{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel07">
+  <h2>Cover-Layout</h2>
+  <label for="title-input">Titel:</label>
+  <input id="title-input" aria-label="Cover-Titel">
+  <label for="color-input">Farbe:</label>
+  <input type="color" id="color-input" value="#ff6699" aria-label="Farbe wählen">
+  <button id="save-btn">Speichern</button>
+  <div id="preview"></div>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+const titleInput=document.getElementById('title-input');
+const colorInput=document.getElementById('color-input');
+const preview=document.getElementById('preview');
+const status=document.getElementById('status');
+const saveBtn=document.getElementById('save-btn');
+const KEY='coverLayout';
+function load(){try{return JSON.parse(localStorage.getItem(KEY))||{};}catch(e){return {};}}
+function save(obj){try{localStorage.setItem(KEY,JSON.stringify(obj));status.textContent='Gespeichert';setTimeout(()=>status.textContent='',3000);}catch(e){status.textContent='Speichern fehlgeschlagen';}}
+function render(obj){preview.style.backgroundColor=obj.color||'#ffffff';preview.textContent=obj.title||'';}
+saveBtn.addEventListener('click',()=>{const obj={title:titleInput.value.trim(),color:colorInput.value};save(obj);render(obj);});
+const data=load();titleInput.value=data.title||'';colorInput.value=data.color||'#ff6699';render(data);
+</script>
+</body>
+</html>

--- a/modules/panel07.html
+++ b/modules/panel07.html
@@ -4,8 +4,8 @@
 <meta charset="UTF-8">
 <title>Panel07 – Cover-Layout</title>
 <style>
-  #panel07{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:sans-serif;}
-  input,button{font-size:1rem;border-radius:0.5rem;}
+  #panel07{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
+  input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   #preview{height:120px;display:flex;align-items:center;justify-content:center;border:1px solid #ccc;}
   @media(min-width:600px){#panel07{max-width:520px;}}
 </style>

--- a/modules/panel08.html
+++ b/modules/panel08.html
@@ -4,8 +4,8 @@
 <meta charset="UTF-8">
 <title>Panel08 – Theme-Switcher</title>
 <style>
-  #panel08{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:sans-serif;}
-  select,button{font-size:1rem;border-radius:0.5rem;}
+  #panel08{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
+  select,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
   @media(min-width:600px){#panel08{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel08.html
+++ b/modules/panel08.html
@@ -5,7 +5,8 @@
 <title>Panel08 – Theme-Switcher</title>
 <style>
   #panel08{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
-  select,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  select,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   @media(min-width:600px){#panel08{max-width:520px;}}
 </style>
 </head>

--- a/modules/panel08.html
+++ b/modules/panel08.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel08 – Theme-Switcher</title>
+<style>
+  #panel08{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:sans-serif;}
+  select,button{font-size:1rem;border-radius:0.5rem;}
+  @media(min-width:600px){#panel08{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel08">
+  <h2>Theme wählen</h2>
+  <label for="theme-select">Farbmodus:</label>
+  <select id="theme-select" aria-label="Theme-Auswahl">
+    <option value="default">Dunkel</option>
+    <option value="light">Hell</option>
+    <option value="blue">Blau</option>
+  </select>
+  <button id="apply-btn">Übernehmen</button>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+const select=document.getElementById('theme-select');
+const btn=document.getElementById('apply-btn');
+const status=document.getElementById('status');
+const KEY='themeSetting';
+function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent='',3000);}
+function applyTheme(t){document.documentElement.setAttribute('data-theme',t==='default'?'' : t);localStorage.setItem(KEY,t);}
+btn.addEventListener('click',()=>{applyTheme(select.value);showStatus('Theme gespeichert');});
+const cur=localStorage.getItem(KEY)||'default';
+select.value=cur;applyTheme(cur);
+</script>
+</body>
+</html>

--- a/modules/panel09.html
+++ b/modules/panel09.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Panel09 – Einstellungen</title>
+<style>
+  #panel09{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:var(--font-family,sans-serif);}
+  select,input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  label{font-size:var(--base-font,1rem);}
+  @media(min-width:600px){#panel09{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="panel09">
+  <h2>Einstellungen</h2>
+  <label for="font-select">Schriftart:</label>
+  <select id="font-select" aria-label="Schrift wählen">
+    <option value="'Segoe UI',Arial,sans-serif">Sans-Serif</option>
+    <option value="'Times New Roman',serif">Serif</option>
+    <option value="'Courier New',monospace">Monospace</option>
+  </select>
+  <label for="size-input">Schriftgröße:</label>
+  <input type="number" id="size-input" value="16" min="12" max="22" aria-label="Schriftgröße in Pixel">
+  <label for="radius-input">Button-Rundung:</label>
+  <select id="radius-input" aria-label="Button-Rundung">
+    <option value="0.3rem">Klein</option>
+    <option value="0.5rem" selected>Mittel</option>
+    <option value="1rem">Rund</option>
+  </select>
+  <button id="save-btn">Speichern</button>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+const fontSel=document.getElementById('font-select');
+const sizeInput=document.getElementById('size-input');
+const radiusSel=document.getElementById('radius-input');
+const status=document.getElementById('status');
+const KEY='appSettings';
+function show(msg){status.textContent=msg;setTimeout(()=>status.textContent='',3000);}
+function apply(s){document.documentElement.style.setProperty('--font-family',s.font);document.documentElement.style.setProperty('--base-font',s.size+'px');document.documentElement.style.setProperty('--btn-radius',s.radius);}
+function load(){try{return JSON.parse(localStorage.getItem(KEY))||{};}catch(e){return {};}}
+function save(obj){try{localStorage.setItem(KEY,JSON.stringify(obj));show('Gespeichert');}catch(e){show('Speichern fehlgeschlagen');}}
+const data=load();
+if(data.font){fontSel.value=data.font;}
+if(data.size){sizeInput.value=data.size;}
+if(data.radius){radiusSel.value=data.radius;}
+apply({font:fontSel.value,size:sizeInput.value,radius:radiusSel.value});
+document.getElementById('save-btn').addEventListener('click',()=>{
+  const obj={font:fontSel.value,size:parseInt(sizeInput.value)||16,radius:radiusSel.value};
+  apply(obj);save(obj);
+});
+</script>
+</body>
+</html>

--- a/modules/panel09.html
+++ b/modules/panel09.html
@@ -5,7 +5,8 @@
 <title>Panel09 – Einstellungen</title>
 <style>
   #panel09{display:grid;gap:0.6rem;max-width:340px;margin:auto;font-family:var(--font-family,sans-serif);}
-  select,input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);}
+  select,input,button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
   label{font-size:var(--base-font,1rem);}
   @media(min-width:600px){#panel09{max-width:520px;}}
 </style>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:33:39 UTC 2025
+Letztes Update: Wed Jul 16 22:43:53 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -15,6 +15,6 @@ Offene Aufgaben:
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
-- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [ ] Story-Sampler-Modul umsetzen (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:49:04 UTC 2025
+Letztes Update: Wed Jul 16 22:54:13 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -17,4 +17,4 @@ Offene Aufgaben:
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
-- [ ] Cover/Layout-Modul umsetzen (Panel07)
+- [x] Cover/Layout-Modul umsetzen (Panel07)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:43:53 UTC 2025
+Letztes Update: Wed Jul 16 22:49:04 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -16,5 +16,5 @@ Offene Aufgaben:
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
-- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 21:37:01 UTC 2025
+Letztes Update: Wed Jul 16 21:42:42 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -8,4 +8,5 @@ Offene Aufgaben:
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:32:09 UTC 2025
+Letztes Update: Wed Jul 16 23:38:16 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -14,7 +14,7 @@ Offene Aufgaben:
 - [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
-- [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [x] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
@@ -23,3 +23,4 @@ Offene Aufgaben:
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
+- [x] Branches zusammenführen (work -> main)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 21:57:44 UTC 2025
+Letztes Update: Wed Jul 16 22:13:00 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -12,3 +12,4 @@ Offene Aufgaben:
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:13:01 UTC 2025
+Letztes Update: Wed Jul 16 23:19:35 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -20,3 +20,4 @@ Offene Aufgaben:
 - [x] Cover/Layout-Modul umsetzen (Panel07)
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
+- [x] Einstellungs-Panel umsetzen (Panel09)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:13:00 UTC 2025
+Letztes Update: Wed Jul 16 22:20:06 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -13,3 +13,4 @@ Offene Aufgaben:
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 21:49:10 UTC 2025
+Letztes Update: Wed Jul 16 21:57:44 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -11,4 +11,4 @@ Offene Aufgaben:
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsmodi mit Profilgewichtung umgesetzt

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:26:51 UTC 2025
+Letztes Update: Wed Jul 16 22:33:39 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -11,7 +11,7 @@ Offene Aufgaben:
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung umsetzen
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:19:35 UTC 2025
+Letztes Update: Wed Jul 16 23:25:12 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -21,3 +21,4 @@ Offene Aufgaben:
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
+- [x] Weitere Befehle in der Laienhilfe ergänzen

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:54:13 UTC 2025
+Letztes Update: Wed Jul 16 22:59:59 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -11,7 +11,7 @@ Offene Aufgaben:
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung umsetzen
+- [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:25:12 UTC 2025
+Letztes Update: Wed Jul 16 23:32:09 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -22,3 +22,4 @@ Offene Aufgaben:
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
+- [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:20:06 UTC 2025
+Letztes Update: Wed Jul 16 22:26:51 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -13,4 +13,8 @@ Offene Aufgaben:
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 22:59:59 UTC 2025
+Letztes Update: Wed Jul 16 23:04:06 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 21:42:42 UTC 2025
+Letztes Update: Wed Jul 16 21:49:10 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -7,6 +7,8 @@ Offene Aufgaben:
 - [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
-- [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] CSS responsiv machen, Test mit Axe/WAVE
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
+- [x] Text-Templates-Modul (Panel04) umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung implementieren

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,10 +1,10 @@
-Letztes Update: Wed Jul 16 04:26:17 UTC 2025
+Letztes Update: Wed Jul 16 21:37:01 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [x] UX-Layout mit Grid/Flex und ARIA-Fokus verbessern
 - [x] commaSplit -> uniqueSort -> JSON-Save/Load umsetzen
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:04:06 UTC 2025
+Letztes Update: Wed Jul 16 23:13:01 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -18,3 +18,5 @@ Offene Aufgaben:
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
+
+- [x] Theme-Switcher-Modul umsetzen (Panel08)

--- a/todo.txt
+++ b/todo.txt
@@ -1,7 +1,7 @@
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [x] UX-Layout mit Grid/Flex und ARIA-Fokus verbessern
 - [x] commaSplit -> uniqueSort -> JSON-Save/Load umsetzen
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE

--- a/todo.txt
+++ b/todo.txt
@@ -11,7 +11,7 @@
 - [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
-- [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [x] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
@@ -20,3 +20,4 @@
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
+- [x] Branches zusammenführen (work -> main)

--- a/todo.txt
+++ b/todo.txt
@@ -13,5 +13,5 @@
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
-- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/todo.txt
+++ b/todo.txt
@@ -14,4 +14,4 @@
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
-- [ ] Cover/Layout-Modul umsetzen (Panel07)
+- [x] Cover/Layout-Modul umsetzen (Panel07)

--- a/todo.txt
+++ b/todo.txt
@@ -8,7 +8,7 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung umsetzen
+- [x] Zufallsmodi mit Profilgewichtung umsetzen (Panel02)
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/todo.txt
+++ b/todo.txt
@@ -8,7 +8,7 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung umsetzen
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/todo.txt
+++ b/todo.txt
@@ -15,3 +15,5 @@
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
+
+- [x] Theme-Switcher-Modul umsetzen (Panel08)

--- a/todo.txt
+++ b/todo.txt
@@ -4,6 +4,8 @@
 - [x] Zufallsprofile ohne Gewichtung umgesetzt (Panel02)
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
-- [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] CSS responsiv machen, Test mit Axe/WAVE
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
+- [x] Text-Templates-Modul (Panel04) umgesetzt
+- [ ] Zufallsmodi mit Profilgewichtung implementieren

--- a/todo.txt
+++ b/todo.txt
@@ -12,6 +12,6 @@
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
 - [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
-- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [ ] Story-Sampler-Modul umsetzen (Panel06)
 - [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/todo.txt
+++ b/todo.txt
@@ -10,3 +10,4 @@
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [ ] GitHub-Remote einrichten und Fortschritt pushen

--- a/todo.txt
+++ b/todo.txt
@@ -18,3 +18,4 @@
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
+- [x] Weitere Befehle in der Laienhilfe ergänzen

--- a/todo.txt
+++ b/todo.txt
@@ -17,3 +17,4 @@
 - [x] Cover/Layout-Modul umsetzen (Panel07)
 
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
+- [x] Einstellungs-Panel umsetzen (Panel09)

--- a/todo.txt
+++ b/todo.txt
@@ -5,4 +5,5 @@
 - [x] Logging ins Dashboard einbauen
 - [x] Clipboard-Funktion mit Feedback-Farben
 - [ ] CSS responsiv machen, Test mit Axe/WAVE
+- [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren

--- a/todo.txt
+++ b/todo.txt
@@ -8,4 +8,4 @@
 - [x] Dashboard-Modul umgesetzt (Panel03)
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
-- [ ] Zufallsmodi mit Profilgewichtung implementieren
+- [x] Zufallsmodi mit Profilgewichtung umgesetzt

--- a/todo.txt
+++ b/todo.txt
@@ -10,4 +10,8 @@
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
 - [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)
+- [x] Modulbezeichnungen in HTML und README vereinheitlicht
 - [ ] GitHub-Remote einrichten und Fortschritt pushen
+- [ ] Persona-Switcher-Modul umsetzen (Panel05)
+- [ ] Story-Sampler-Modul umsetzen (Panel06)
+- [ ] Cover/Layout-Modul umsetzen (Panel07)

--- a/todo.txt
+++ b/todo.txt
@@ -9,3 +9,4 @@
 - [x] Platzhalter-Datei automatisch mit todo.txt aktualisieren
 - [x] Text-Templates-Modul (Panel04) umgesetzt
 - [x] Zufallsmodi mit Profilgewichtung umgesetzt
+- [x] Nutzerfreundlichkeit & Fehlerbehandlung verbessert (Panel01/02)

--- a/todo.txt
+++ b/todo.txt
@@ -19,3 +19,4 @@
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
+- [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)


### PR DESCRIPTION
## Summary
- implement panel02 for storing multiple genre profiles
- document new module in README
- update todo lists
- regenerate placeholder and tree data via selfcheck

## Testing
- `bash tools/selfcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_6878179592f88325988f565d16577e7d