### PR TITLE
Add date/time display to dashboard

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -188,3 +188,14 @@ git push
 ```
 Damit sind die Zweige vereint und online gesichert.
 
+## Datum und Uhrzeit im Dashboard
+
+Im Dashboard (Panel03) steht jetzt oben die aktuelle Uhrzeit und das Datum. Die Anzeige
+aktualisiert sich jede Sekunde von selbst.
+
+- Uhrzeit im Terminal anzeigen:
+  ```bash
+  date
+  ```
+  (Zeigt Datum und Zeit an)
+

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - **🎛 Panel02: Genre-Profile**
   → Mehrere Genre-Listen unter Profilnamen speichern, optional mit Gewichtung
   → Button "Gewichteter Zufall" wählt ein Profil nach Gewicht und daraus ein Genre
-- **📊 Panel03: Dashboard – Verlauf**
+ - **📊 Panel03: Dashboard – Verlauf**
   → Zufallsausgaben aus allen Modulen zentral anzeigen und löschen
+  → Oben laufende Anzeige von Datum und Uhrzeit
 - **📋 Panel04: Textbausteine**
   → Kurze Textbausteine speichern und per Klick in die Zwischenablage kopieren
 - **🧑‍🎤 Panel05: Persona-Switcher**

--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -11,7 +11,7 @@
 ./branch-limit.yml
 ./data/baumstruktur.txt
 ./data/todo.txt
-./data/todo_backup_20250716233816.txt
+./data/todo_backup_20250717170755.txt
 ./index-DDD.html
 ./modules.json
 ./modules/panel01.html

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -21,3 +21,4 @@
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
 - [x] Branches zusammenführen (work -> main)
+- [x] Datum & Uhrzeit im Dashboard anzeigen (Panel03)

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -37,7 +37,7 @@ const DASH_KEY='dashboardLog';
 
 function addDashboard(val){
   const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
-  arr.unshift({time:new Date().toLocaleTimeString(),value:val});
+  arr.unshift({time:new Date().toLocaleString(),value:val});
   if(arr.length>10) arr.length=10;
   localStorage.setItem(DASH_KEY,JSON.stringify(arr));
 }
@@ -80,7 +80,7 @@ randomBtn.addEventListener('click',()=>{
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
-  entry.textContent=new Date().toLocaleTimeString()+': '+choice;
+  entry.textContent=new Date().toLocaleString()+': '+choice;
   log.prepend(entry);
   addDashboard(choice);
 });

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -51,7 +51,7 @@ const DASH_KEY='dashboardLog';
 
 function addDashboard(val){
   const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');
-  arr.unshift({time:new Date().toLocaleTimeString(),value:val});
+  arr.unshift({time:new Date().toLocaleString(),value:val});
   if(arr.length>10) arr.length=10;
   localStorage.setItem(DASH_KEY,JSON.stringify(arr));
 }
@@ -131,7 +131,7 @@ randomBtn.addEventListener('click',()=>{
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const entry=document.createElement('li');
-  entry.textContent=new Date().toLocaleTimeString()+': '+choice;
+  entry.textContent=new Date().toLocaleString()+': '+choice;
   log.prepend(entry);
   addDashboard(choice);
 });
@@ -152,7 +152,7 @@ weightedBtn.addEventListener('click',()=>{
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;
   const li=document.createElement('li');
-  li.textContent=new Date().toLocaleTimeString()+': '+choice+' ('+picked+')';
+  li.textContent=new Date().toLocaleString()+': '+choice+' ('+picked+')';
   log.prepend(li);
   addDashboard(choice);
 });

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -5,6 +5,7 @@
 <title>Panel03 – Dashboard: Verlauf</title>
 <style>
   #panel03{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family, sans-serif);}
+  #current-time{font-size:.9em;color:var(--text-light,#555);}
   #log-list{max-height:120px;overflow-y:auto;padding-left:1rem;}
   button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,0.5rem);line-height:1.4;}
   button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
@@ -14,6 +15,7 @@
 <body>
 <div id="panel03">
   <h2>Dashboard – Verlauf</h2>
+  <div id="current-time"></div>
   <ul id="log-list"></ul>
   <button id="clear-btn">Alles löschen</button>
 </div>
@@ -21,6 +23,13 @@
 const STORAGE_KEY='dashboardLog';
 const list=document.getElementById('log-list');
 const clearBtn=document.getElementById('clear-btn');
+const timeDiv=document.getElementById('current-time');
+
+function updateTime(){
+  timeDiv.textContent=new Date().toLocaleString();
+}
+setInterval(updateTime,1000);
+updateTime();
 function loadLog(){
   const data=localStorage.getItem(STORAGE_KEY);
   return data?JSON.parse(data):[];

--- a/modules/panel06.html
+++ b/modules/panel06.html
@@ -38,10 +38,10 @@ const DASH_KEY='dashboardLog';
 function showStatus(msg){status.textContent=msg;setTimeout(()=>status.textContent='',3000);}
 function loadList(){try{return JSON.parse(localStorage.getItem(STORE_KEY))||[];}catch(e){showStatus('Laden fehlgeschlagen');return [];}}
 function saveList(list){try{localStorage.setItem(STORE_KEY,JSON.stringify(list));}catch(e){showStatus('Speichern fehlgeschlagen');}}
-function addDashboard(val){const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');arr.unshift({time:new Date().toLocaleTimeString(),value:val});if(arr.length>10) arr.length=10;localStorage.setItem(DASH_KEY,JSON.stringify(arr));}
+function addDashboard(val){const arr=JSON.parse(localStorage.getItem(DASH_KEY)||'[]');arr.unshift({time:new Date().toLocaleString(),value:val});if(arr.length>10) arr.length=10;localStorage.setItem(DASH_KEY,JSON.stringify(arr));}
 function render(){const list=loadList();input.value=list.join('\n');}
 saveBtn.addEventListener('click',()=>{const list=input.value.split('\n').map(s=>s.trim()).filter(Boolean);saveList(list);showStatus('Gespeichert');});
-randomBtn.addEventListener('click',()=>{const list=input.value.split('\n').map(s=>s.trim()).filter(Boolean);if(list.length===0){showStatus('Keine Einträge');return;}const choice=list[Math.floor(Math.random()*list.length)];output.textContent=choice;const li=document.createElement('li');li.textContent=new Date().toLocaleTimeString()+': '+choice;log.prepend(li);addDashboard(choice);});
+randomBtn.addEventListener('click',()=>{const list=input.value.split('\n').map(s=>s.trim()).filter(Boolean);if(list.length===0){showStatus('Keine Einträge');return;}const choice=list[Math.floor(Math.random()*list.length)];output.textContent=choice;const li=document.createElement('li');li.textContent=new Date().toLocaleString()+': '+choice;log.prepend(li);addDashboard(choice);});
 copyBtn.addEventListener('click',()=>{const text=output.textContent;if(!text){showStatus('Nichts zum Kopieren');return;}navigator.clipboard.writeText(text).then(()=>{copyBtn.style.backgroundColor='#15b57b';setTimeout(()=>{copyBtn.style.backgroundColor='';},800);});});
 render();
 </script>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -1,4 +1,4 @@
-Letztes Update: Wed Jul 16 23:38:16 UTC 2025
+Letztes Update: Thu Jul 17 17:07:55 UTC 2025
 
 Offene Aufgaben:
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
@@ -24,3 +24,4 @@ Offene Aufgaben:
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
 - [x] Branches zusammenführen (work -> main)
+- [x] Datum & Uhrzeit im Dashboard anzeigen (Panel03)

--- a/todo.txt
+++ b/todo.txt
@@ -21,3 +21,4 @@
 - [x] Weitere Befehle in der Laienhilfe ergänzen
 - [x] Tastaturfokus sichtbarer gemacht (Focus-Ring)
 - [x] Branches zusammenführen (work -> main)
+- [x] Datum & Uhrzeit im Dashboard anzeigen (Panel03)


### PR DESCRIPTION
## Summary
- display running date/time on Panel03 dashboard
- include timestamp (date + time) in random logs
- document new feature in README and LAIENHILFE
- update todo and placeholder files

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_68792d194e3c8325b1106afc4b173422