### PR TITLE
Improve help and tooltips

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -47,6 +47,13 @@ Damit startet ein Server (kleines Programm zur Bereitstellung der Dateien) und �
 3. Öffne dann `http://localhost:8000/index-MODULTOOL.html` im Browser (Programm zum Surfen im Internet).
 4. Mit `Strg+C` beendest du den Server wieder.
 
+## Tooltips & Eingabehilfen
+
+- Viele Felder zeigen nun Beispieltexte *(Placeholder = Platzhalter)*.
+- Halte die Maus über ein Eingabefeld, um einen **Tooltip** (kurzer Hinweis) zu sehen.
+- Beispiel: Im Modul *Persona-Switcher* weist das Namensfeld mit "Name des Profils" auf den Zweck hin.
+- Diese Tipps helfen, schneller zu verstehen, was eingetragen werden soll.
+
 ## Eigene Module erstellen
 
 1. Lege die Ordner `modules` und `panels` an, falls sie fehlen. Das machst du im Terminal (Eingabeprogramm) so:

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -154,3 +154,4 @@
 - [x] Platzhalter-Module bereinigen
 - [x] Panel01 HTML aufräumen
 - [x] modules.json IDs an HTML angepasst
+- [x] Hilfetexte und Tooltips erweitert, Eingabefelder mit Platzhaltern versehen

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -15,9 +15,11 @@
 <div id="panel02">
   <h2>Textbausteine</h2>
   <label for="tmpl-title">Titel:</label>
-  <input id="tmpl-title" type="text" aria-label="Titel" required />
+  <input id="tmpl-title" type="text" aria-label="Titel"
+         placeholder="z.B. Begrüßung" title="Kurzbeschreibung der Vorlage" required />
   <label for="tmpl-text">Text:</label>
-  <textarea id="tmpl-text" rows="2" aria-label="Textvorlage" required></textarea>
+  <textarea id="tmpl-text" rows="2" aria-label="Textvorlage"
+            placeholder="Inhalt hier eingeben" title="Text für die Vorlage" required></textarea>
   <button id="add-btn">Hinzufügen</button>
   <ul id="tmpl-list"></ul>
   <div id="status" role="status" aria-live="polite"></div>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -16,15 +16,16 @@
 <div id="panel03">
   <h2>Dashboard – Verlauf</h2>
   <div>
-    <label for="moduleSelect">Modul öffnen:</label>
-    <select id="moduleSelect"></select>
-    <button id="openModuleBtn">Öffnen</button>
+  <label for="moduleSelect">Modul öffnen:</label>
+  <select id="moduleSelect" title="Modul aus der Liste wählen"></select>
+  <button id="openModuleBtn" title="Gewähltes Modul im neuen Tab anzeigen">Öffnen</button>
+  <div class="input-help">Wähle ein Modul und klicke auf Öffnen. Es erscheint in einem neuen Tab.</div>
   </div>
   <h3>Nächste Termine</h3>
   <ul id="next-list"></ul>
   <div id="current-time"></div>
   <ul id="log-list"></ul>
-  <button id="clear-btn">Alles löschen</button>
+  <button id="clear-btn" title="Verlauf komplett leeren">Alles löschen</button>
 </div>
 <script type="module">
 const STORAGE_KEY='dashboardLog';

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -18,9 +18,11 @@
 <div id="panel04">
   <h2>Textbausteine</h2>
   <label for="title-input">Titel:</label>
-  <input id="title-input" aria-label="Template-Titel">
+  <input id="title-input" aria-label="Template-Titel"
+         placeholder="z.B. Überschrift" title="Name des Textbausteins">
   <label for="text-input">Text:</label>
-  <textarea id="text-input" aria-label="Template-Text"></textarea>
+  <textarea id="text-input" aria-label="Template-Text"
+            placeholder="Text hier eingeben" title="Inhalt des Textbausteins"></textarea>
   <button id="add-btn">Hinzufügen</button>
   <div id="template-list"></div>
 </div>

--- a/modules/panel05.html
+++ b/modules/panel05.html
@@ -15,9 +15,11 @@
 <div id="panel05">
   <h2>Persona-Switcher</h2>
   <label for="persona-name">Name:</label>
-  <input id="persona-name" aria-label="Persona-Name">
+  <input id="persona-name" aria-label="Persona-Name"
+         placeholder="z.B. Popstar" title="Name des Profils">
   <label for="persona-desc">Beschreibung:</label>
-  <textarea id="persona-desc" aria-label="Persona-Beschreibung"></textarea>
+  <textarea id="persona-desc" aria-label="Persona-Beschreibung"
+            placeholder="Stil, Stimme, Eigenheiten" title="Kurzbeschreibung"></textarea>
   <button id="add-btn">Profil speichern</button>
   <label for="persona-select">Profil wählen:</label>
   <select id="persona-select"></select>

--- a/modules/panel09.html
+++ b/modules/panel09.html
@@ -29,7 +29,8 @@
     <option value="1rem">Rund</option>
   </select>
   <label for="path-input">Standardpfad:</label>
-  <input id="path-input" placeholder="./data" aria-label="Standardpfad">
+  <input id="path-input" placeholder="./data" aria-label="Standardpfad"
+         title="Ordner für Importe und Exporte">
   <button id="save-btn">Speichern</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/todo.txt
+++ b/todo.txt
@@ -154,3 +154,4 @@
 - [x] Platzhalter-Module bereinigen
 - [x] Panel01 HTML aufräumen
 - [x] modules.json IDs an HTML angepasst
+- [x] Hilfetexte und Tooltips erweitert, Eingabefelder mit Platzhaltern versehen


### PR DESCRIPTION
## Summary
- add placeholders and tooltips to several module forms
- show hint in dashboard panel how to open modules
- document new tips section in `LAIENHILFE.md`
- sync updated `todo.txt`

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687989f48c6083258accbdae20deca04