### PR TITLE
Fix intro overlay auto-close

### DIFF
--- a/data/baumstruktur.txt
+++ b/data/baumstruktur.txt
@@ -23,9 +23,9 @@
 ./.git/logs/HEAD
 ./.git/logs/refs/heads/main
 ./.git/logs/refs/heads/work
-./.git/objects/pack/pack-ed2e647b3c4b4386da3d1d8e784825eba9043eee.idx
-./.git/objects/pack/pack-ed2e647b3c4b4386da3d1d8e784825eba9043eee.pack
-./.git/objects/pack/pack-ed2e647b3c4b4386da3d1d8e784825eba9043eee.rev
+./.git/objects/pack/pack-2ea912e8c6a3c9abe0e303d0d97287bce2b5e06e.idx
+./.git/objects/pack/pack-2ea912e8c6a3c9abe0e303d0d97287bce2b5e06e.pack
+./.git/objects/pack/pack-2ea912e8c6a3c9abe0e303d0d97287bce2b5e06e.rev
 ./.git/packed-refs
 ./.git/refs/heads/main
 ./.git/refs/heads/work
@@ -82,6 +82,7 @@
 ./modules/panel11.html
 ./modules/panel12.html
 ./modules/panel13.html
+./modules/panel14.html
 ./modules/panel_template.html
 ./modules/persona_switcher.html
 ./modules/projektorganizer.html

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -177,7 +177,9 @@
 - [x] Laienhilfe erweitert (Bearbeiten und Testbefehle)
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
+- [x] Panel02 Buttons & Events bereinigt
 - [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
+- [x] Startbildschirm schließt automatisch nach 20 Sekunden

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -999,6 +999,8 @@ function loadRegisteredPanels(){
     .catch(e=>logErr('Module-Liste: '+e));
 }
 loadRegisteredPanels();
+// Intro-Overlay nach 20 Sekunden automatisch ausblenden
+setTimeout(hideIntro, 20000);
 function hideIntro(){
   const el = document.getElementById('introOverlay');
   if(el) el.style.display='none';

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -178,3 +178,8 @@
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
+- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [ ] Startskript prüft Updates vor dem Start
+- [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
+- [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
+- [x] Startbildschirm schließt automatisch nach 20 Sekunden

--- a/todo.txt
+++ b/todo.txt
@@ -182,3 +182,4 @@
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
+- [x] Startbildschirm schließt automatisch nach 20 Sekunden


### PR DESCRIPTION
## Summary
- auto-close intro overlay after 20 seconds
- update task lists and project tree

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879a62ed1bc8325999269eaab2aef22