### PR TITLE
Fix intro overlay timer

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -42,6 +42,7 @@ bash tools/start_tool.sh
 
 Damit startet ein Server (kleines Programm zur Bereitstellung der Dateien) und öffnet die Seite automatisch im Browser.
 
+Beim Laden erscheint ein kurzes Willkommensfenster. Es schließt sich nach 20 Sekunden automatisch oder per Klick auf 'Los geht's'.
 1. Wechsel im Terminal in den Projektordner.
 2. Starte einen kleinen Webserver mit `python3 -m http.server`. (Damit werden die Dateien lokal bereitgestellt.)
 3. Öffne dann `http://localhost:8000/index-MODULTOOL.html` im Browser (Programm zum Surfen im Internet).

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -15,6 +15,7 @@
 - [x] Hilfetexte und Tooltips ausbauen
 - [x] Startskript zum einfachen Aufrufen des Tools
 - [x] Willkommens-Overlay für neue Nutzer
+- [x] Startbildschirm blendet nach 20 Sekunden aus
 - [x] Importfunktion: geladenes Modul direkt als Panel einfügen
 - [x] Module automatisch aus modules.json laden
 - [x] Neues Modul panel10 "Erste Schritte" ergänzen
@@ -177,6 +178,7 @@
 - [x] Laienhilfe erweitert (Bearbeiten und Testbefehle)
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
+- [x] Panel02 Buttons & Events bereinigt
 - [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -999,6 +999,7 @@ function loadRegisteredPanels(){
     .catch(e=>logErr('Module-Liste: '+e));
 }
 loadRegisteredPanels();
+setTimeout(hideIntro, 20000);
 function hideIntro(){
   const el = document.getElementById('introOverlay');
   if(el) el.style.display='none';

--- a/todo.txt
+++ b/todo.txt
@@ -15,6 +15,7 @@
 - [x] Hilfetexte und Tooltips ausbauen
 - [x] Startskript zum einfachen Aufrufen des Tools
 - [x] Willkommens-Overlay für neue Nutzer
+- [x] Startbildschirm blendet nach 20 Sekunden aus
 - [x] Importfunktion: geladenes Modul direkt als Panel einfügen
 - [x] Module automatisch aus modules.json laden
 - [x] Neues Modul panel10 "Erste Schritte" ergänzen


### PR DESCRIPTION
## Summary
- add automatic hide after 20s for intro screen
- note new behavior in LAIENHILFE
- log change in todo

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687abd7e95b483259e807217ee2bedc5