### PR TITLE
Improve error log handling

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -19,7 +19,7 @@ Dabei wird deine Aufgabenliste automatisch gesichert und
 ```bash
 bash tools/selfcheck.sh
 ```
-Dabei wird automatisch `platzhalter.txt` auf Basis von `todo.txt` aktualisiert.
+4. Öffne `modules/panel14.html` im Browser. Dort siehst du gespeicherte Fehlermeldungen. Mit **Fehler speichern** lädst du sie herunter, **Fehler löschen** leert die Liste.
 
 Falls Meldungen erscheinen, befolge die Tipps. Zum Beispiel wird `htmlhint` erwähnt, wenn es fehlt. Dann kannst du es mit `npm install -g htmlhint` (JavaScript-Prüfwerkzeug) installieren.
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -177,7 +177,9 @@
 - [x] Laienhilfe erweitert (Bearbeiten und Testbefehle)
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [x] Panel02 Buttons & Events bereinigt
+- [x] Fehler-&-Hilfe-Panel speichert Fehler in localStorage und bietet Download
+- [x] handleError-Funktion speichert Fehlermeldungen automatisch
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -43,6 +43,7 @@
 </div>
 <script type="module">
 import {showStatus, addDashboard} from './common.js';
+import {handleError} from '../validation.js';
 const input=document.getElementById('genre-input');
 const saveBtn=document.getElementById('save-btn');
 const randomBtn=document.getElementById('random-btn');
@@ -65,6 +66,7 @@ function saveList(){
     showStatus(statusEl,'Liste gespeichert');
   }catch(e){
     showStatus(statusEl,'Speichern fehlgeschlagen');
+    handleError(e,'Genres speichern');
   }
   return list;
 }
@@ -78,6 +80,7 @@ function loadList(){
   }catch(e){
     showStatus(statusEl,'Laden fehlgeschlagen');
     showStatus(status,'Laden fehlgeschlagen');
+    handleError(e,'Genres laden');
   }
 }
 
@@ -89,6 +92,7 @@ function saveList(){
     showStatus(status,'Liste gespeichert');
   }catch(e){
     showStatus(status,'Speichern fehlgeschlagen');
+    handleError(e,'Genres speichern');
   }
 }
 
@@ -116,7 +120,7 @@ copyBtn.addEventListener('click',()=>{
     navigator.clipboard.writeText(text).then(()=>{
       copyBtn.style.backgroundColor='#15b57b';
       setTimeout(()=>{copyBtn.style.backgroundColor='';},800);
-    }).catch(err=>{console.warn('Clipboard-Fehler',err);});
+    }).catch(err=>{console.warn('Clipboard-Fehler',err); handleError(err,'Clipboard');});
   }else{
     console.warn('Clipboard-API nicht verfügbar');
   }
@@ -124,7 +128,7 @@ copyBtn.addEventListener('click',()=>{
   navigator.clipboard.writeText(text).then(()=>{
     copyBtn.style.backgroundColor='#15b57b';
     setTimeout(()=>copyBtn.style.backgroundColor='',800);
-  }).catch(()=>showStatus(status,'Kopieren fehlgeschlagen'));
+  }).catch(e=>{showStatus(status,'Kopieren fehlgeschlagen'); handleError(e,'Clipboard');});
 });
 
 loadList();

--- a/modules/panel07.html
+++ b/modules/panel07.html
@@ -25,6 +25,7 @@
 </div>
 <script type="module">
 import { showStatus, addDashboard } from './common.js';
+import { handleError } from '../validation.js';
 const titleInput=document.getElementById('title-input');
 const colorInput=document.getElementById('color-input');
 const preview=document.getElementById('preview');
@@ -36,6 +37,7 @@ function load(){
   try {
     return JSON.parse(localStorage.getItem(KEY)) || {};
   } catch(e) {
+    handleError(e,'Cover laden');
     return {};
   }
 }
@@ -47,6 +49,7 @@ function saveData(obj){
     addDashboard('Cover: ' + (obj.title || ''));
   } catch(e) {
     showStatus(status, 'Speichern fehlgeschlagen');
+    handleError(e,'Cover speichern');
   }
 }
 
@@ -62,11 +65,16 @@ saveBtn.addEventListener('click', () => {
 });
 
 resetBtn.addEventListener('click', () => {
-  localStorage.removeItem(KEY);
-  titleInput.value = '';
-  colorInput.value = '#ff6699';
-  render({});
-  showStatus(status, 'Zur\u00fcckgesetzt');
+  try {
+    localStorage.removeItem(KEY);
+    titleInput.value = '';
+    colorInput.value = '#ff6699';
+    render({});
+    showStatus(status, 'Zur\u00fcckgesetzt');
+  } catch(e){
+    showStatus(status,'Zur\u00fccksetzen fehlgeschlagen');
+    handleError(e,'Cover reset');
+  }
 });
 
 const data = load();

--- a/modules/panel14.html
+++ b/modules/panel14.html
@@ -13,10 +13,36 @@
   <h2>Fehler & Hilfe</h2>
   <a href="LAIENHILFE.md" target="_blank">Ausführliche Hilfe öffnen</a>
   <pre id="errorInfo" style="max-height:150px;overflow:auto;background:#222;color:#eee;padding:.4em;"></pre>
-  <script>
-    fetch("error_informationen.txt")
-      .then(r => r.text())
-      .then(t => { document.getElementById("errorInfo").textContent = t || "Keine Fehlerhinweise vorhanden."; });
+  <button id="saveErrorsBtn">Fehler speichern</button>
+  <button id="clearErrorsBtn">Fehler löschen</button>
+  <script type="module">
+    import { handleError } from '../validation.js';
+    const info=document.getElementById('errorInfo');
+    function loadLog(){
+      try{
+        const log=JSON.parse(localStorage.getItem('errorLog')||'[]');
+        info.textContent=log.map(e=>`[${e.time}] ${e.msg}`).join('\n')||'Keine Fehler gespeichert.';
+        return true;
+      }catch(e){
+        info.textContent='Fehler beim Laden des Logs';
+        handleError(e,'Fehlerlog laden');
+        return false;
+      }
+    }
+    document.getElementById('saveErrorsBtn').addEventListener('click',()=>{
+      const blob=new Blob([info.textContent],{type:'text/plain'});
+      const url=URL.createObjectURL(blob);
+      const a=document.createElement('a');
+      a.href=url; a.download='error_log.txt'; a.click();
+      URL.revokeObjectURL(url);
+    });
+    document.getElementById('clearErrorsBtn').addEventListener('click',()=>{
+      localStorage.removeItem('errorLog');
+      loadLog();
+    });
+    window.addEventListener('error',e=>handleError(e.error||e.message,'Global'));
+    window.addEventListener('unhandledrejection',e=>handleError(e.reason,'Promise'));
+    loadLog();
   </script>
 </div>
 </body>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -178,3 +178,8 @@
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
+- [x] Fehler-&-Hilfe-Panel speichert Fehler in localStorage und bietet Download
+- [x] handleError-Funktion speichert Fehlermeldungen automatisch
+- [ ] Startskript prüft Updates vor dem Start
+- [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
+- [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/todo.txt
+++ b/todo.txt
@@ -178,7 +178,8 @@
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [x] Fehler-&-Hilfe-Panel speichert Fehler in localStorage und bietet Download
+- [x] handleError-Funktion speichert Fehlermeldungen automatisch
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/validation.js
+++ b/validation.js
@@ -53,3 +53,16 @@ export function saveJSON(key, data) {
     return false;
   }
 }
+
+export function handleError(err, msg = '') {
+  console.warn('Fehler:', msg, err);
+  if (!hasLocalStorage()) return;
+  try {
+    const log = JSON.parse(localStorage.getItem('errorLog') || '[]');
+    log.unshift({ time: new Date().toLocaleString(), msg: msg || String(err) });
+    if (log.length > 20) log.pop();
+    localStorage.setItem('errorLog', JSON.stringify(log));
+  } catch (e) {
+    console.warn('Fehler beim Schreiben des Fehlerlogs', e);
+  }
+}


### PR DESCRIPTION
## Summary
- add `handleError` helper for auto logging
- show error log in Fehler-&-Hilfe panel with save/clear buttons
- log errors from Cover-Layout and Genre-Liste modules
- document error log usage in LAIENHILFE
- update todo lists

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ac325b7f083259087b8d71508c868