### PR TITLE
Improve help panel and docs

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -285,6 +285,17 @@ sudo apt-get install -y shellcheck npm
 sudo npm install -g htmlhint
 ```
 
+## Fehler & Hilfe-Panel nutzen
+
+1. Öffne `modules/panel14.html` im Browser.
+2. Das Panel liest die Datei `error_informationen.txt` und zeigt sie im Textfeld an.
+3. Aktualisiere die Datei bei Bedarf mit:
+   ```bash
+   nano error_informationen.txt
+   ```
+   *("nano" ist ein einfacher Texteditor im Terminal.)*
+4. Seite neu laden (**F5**), um die Änderungen zu sehen.
+
 ## Textbaustein-Modul benutzen
 
 1. Öffne `panel04.html` im Ordner `modules`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - [Branches zusammenführen](#-branches-zusammenführen)
 - [Neues Modul anlegen](#neues-modul-anlegen)
 - [Pakete erstellen (.deb & AppImage)](#-pakete-erstellen-deb--appimage)
+- [Hilfe](#hilfe)
 Zum Starten: `bash tools/start_tool.sh` – überprüft neue Module und öffnet das Tool.
 
 Der Selfcheck (`bash tools/selfcheck.sh`) fungiert als einfacher HTML-Fehler-Checker und synchronisiert deine Aufgabenlisten.
@@ -122,3 +123,7 @@ python3 -m http.server
 ```
 
 Öffne danach `http://localhost:8000` im Browser. So lassen sich alle Module testen, ohne Dateien doppelt anzuklicken.
+
+## Hilfe
+
+Ausführliche Tipps findest du in der Datei [LAIENHILFE.md](LAIENHILFE.md). Dort stehen alle Schritte in einfacher Sprache mit Beispielen.

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -177,7 +177,8 @@
 - [x] Laienhilfe erweitert (Bearbeiten und Testbefehle)
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [x] Panel02 Buttons & Events bereinigt
+- [x] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
-- [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
-- [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
+- [x] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
+- [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/modules/panel14.html
+++ b/modules/panel14.html
@@ -14,7 +14,7 @@
   <a href="LAIENHILFE.md" target="_blank">Ausführliche Hilfe öffnen</a>
   <pre id="errorInfo" style="max-height:150px;overflow:auto;background:#222;color:#eee;padding:.4em;"></pre>
   <script>
-    fetch("error_informationen.txt")
+    fetch("../error_informationen.txt")
       .then(r => r.text())
       .then(t => { document.getElementById("errorInfo").textContent = t || "Keine Fehlerhinweise vorhanden."; });
   </script>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -178,3 +178,7 @@
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
+- [x] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [ ] Startskript prüft Updates vor dem Start
+- [x] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
+- [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/todo.txt
+++ b/todo.txt
@@ -178,7 +178,7 @@
 
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
+- [x] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
-- [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
-- [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
+- [x] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
+- [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/tools/selfcheck.sh
+++ b/tools/selfcheck.sh
@@ -6,6 +6,7 @@ echo "🧪 Selfcheck gestartet..."
 # Haupt-ToDo-Dateien festlegen
 TODO_MAIN="todo.txt"
 TODO_DATA="data/todo.txt"
+TODO_COPY="platzhalter.txt"
 
 # Backup der Haupt-ToDo-Datei erstellen
 if [ -f "$TODO_MAIN" ]; then
@@ -22,6 +23,9 @@ fi
 if [ -f "$TODO_MAIN" ]; then
   if [ ! -f "$TODO_DATA" ] || ! diff -q "$TODO_MAIN" "$TODO_DATA" >/dev/null; then
     cp "$TODO_MAIN" "$TODO_DATA"
+  fi
+  if [ ! -f "$TODO_COPY" ] || ! diff -q "$TODO_MAIN" "$TODO_COPY" >/dev/null; then
+    cp "$TODO_MAIN" "$TODO_COPY"
   fi
 fi
 
@@ -89,7 +93,7 @@ fi
 
 # ========== Hinweise zum manuellen Aktualisieren ==========
 echo "🌲 baumstruktur.txt manuell mit 'find . -type f | sort > data/baumstruktur.txt' aktualisieren"
-echo "📑 platzhalter.txt manuell aus todo.txt generieren"
+echo "📑 platzhalter.txt automatisch aktualisiert"
 
 # ========== Merge-Konfliktmarker prüfen ==========
 # ToDo-Dateien nach Prüfung synchronisieren


### PR DESCRIPTION
## Summary
- link help section from the README table of contents and add a short help section
- describe the help panel in LAIENHILFE
- load `error_informationen.txt` correctly in panel14
- keep `platzhalter.txt` in sync via selfcheck
- mark completed tasks in todo list

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ac384afc48325b3a7967ae44bf717