### PR TITLE
Add selfcheck npm script and shared CSS

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -862,3 +862,13 @@ Mit der Zeit sammeln sich leere Dateien oder doppelte Einträge an. So bringst d
   Profil auswählen und auf "Profil löschen" klicken
   ```
   *(Entfernt das Profil dauerhaft aus dem Browser-Speicher (localStorage).)*
+
+## Neu: Selbstcheck mit npm
+Falls Node (Laufzeit für JavaScript) installiert ist, reicht ein kurzer Befehl:
+```bash
+npm run selfcheck
+```
+Damit rufst du `tools/selfcheck.sh` auf und prüfst das Projekt automatisch.
+
+## Gemeinsame CSS-Datei
+Alle Module nutzen nun `modules/common.css`. Hier kannst du das Aussehen zentral anpassen.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ python3 -m http.server
 ```
 
 Öffne danach `http://localhost:8000` im Browser. So lassen sich alle Module testen, ohne Dateien doppelt anzuklicken.
+## ♻ Optimierungsideen
+- Nutze `npm run selfcheck` (führt das Prüfskript aus).
+- Sichere Zwischenstände mit `git stash` (temporärer Speicher).
+- Erstelle neue Module mit `node tools/create_module.js modulID "Titel"`.
 
 ## Hilfe
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -81,6 +81,7 @@
 - [x] Persona-Switcher-Modul umsetzen (Panel05)
 - [x] Story-Sampler-Modul umgesetzt (Panel06)
 - [x] Cover/Layout-Modul umsetzen (Panel07)
+
 - [x] Theme-Switcher-Modul umsetzen (Panel08)
 - [x] Einstellungs-Panel umsetzen (Panel09)
 - [x] Weitere Befehle in der Laienhilfe ergänzen
@@ -149,6 +150,7 @@
 - [ ] GitHub Actions für Linting und Testing hinzufügen
 - [ ] Schritt-für-Schritt-Assistenten für Modul-Erstellung planen
 - [ ] Barrierefreiheit automatisch prüfen (axe-core)
+
 - [x] LAIENHILFE um Aufräumtipps ergänzt
 - [x] HTML-Dateien um Doctype erweitern (automatisiert)
 - [x] Platzhalter-Module bereinigen
@@ -156,23 +158,25 @@
 - [x] Panel01 doppelte IDs entfernt
 - [x] modules.json IDs an HTML angepasst
 - [x] Hilfetexte und Tooltips erweitert, Eingabefelder mit Platzhaltern versehen
-- [ ] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
+- [x] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
 - [ ] Unnötige Platzhalter-Dateien entfernen
-- [ ] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
+- [x] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
 - [ ] GitHub-Workflow test.yml für automatische Prüfungen
-- [ ] README um Abschnitt 'Optimierungsideen' ergänzen
+- [x] README um Abschnitt 'Optimierungsideen' ergänzen
 - [x] Zusätzliche Tooltips für Buttons (Panel01/02/04)
 - [x] Laienhilfe um Cronjob und Tooltip-Hinweis ergänzt
-- [ ] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
+- [x] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
 - [x] Fehlerhandling und Validation verbessert (validation.js, Panel10/11)
 - [x] LAIENHILFE und DOKUMENTATION um Todo-Hinweise erweitert
 - [x] panel07 nutzt common.js, Reset-Funktion ergänzt
 - [x] Story-Sampler: 'Liste löschen'-Button und Kopiermeldung
 - [x] Persona-Switcher um Löschfunktion erweitert (Panel05)
 - [x] Panel04 auf common.js umgestellt und um Feedback erweitert
+
 - [x] Exportfunktion im Dashboard ergänzt (Panel03)
 - [x] Panel02: Bearbeiten-Funktion ergänzt
 - [x] Laienhilfe erweitert (Bearbeiten und Testbefehle)
+
 - [x] panel01 Code aufgeraeumt (doppelte Funktionen entfernt und common.js genutzt)
 - [x] Panel02 Buttons & Events bereinigt
 - [x] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
@@ -181,7 +185,6 @@
 - [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 - [x] Fehler-&-Hilfe-Panel speichert Fehler in localStorage und bietet Download
 - [x] handleError-Funktion speichert Fehlermeldungen automatisch
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GridTool Pro – Fokus & Themes</title>
+  <link rel="stylesheet" href="modules/common.css" />
   <style>
     :root {
       --sidebar-width-left: 240px;

--- a/modules/common.css
+++ b/modules/common.css
@@ -1,0 +1,8 @@
+/* Gemeinsame Stilregeln fuer alle Module */
+.mod-panel {
+  padding: 1rem;
+  border-radius: 1rem;
+}
+.mod-panel h2 {
+  margin-top: 0;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "modultool",
+  "version": "0.1.0",
+  "scripts": {
+    "selfcheck": "bash tools/selfcheck.sh"
+  }
+}

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -15,6 +15,7 @@
 - [x] Hilfetexte und Tooltips ausbauen
 - [x] Startskript zum einfachen Aufrufen des Tools
 - [x] Willkommens-Overlay für neue Nutzer
+- [x] Startbildschirm blendet nach 20 Sekunden aus
 - [x] Importfunktion: geladenes Modul direkt als Panel einfügen
 - [x] Module automatisch aus modules.json laden
 - [x] Neues Modul panel10 "Erste Schritte" ergänzen
@@ -157,14 +158,14 @@
 - [x] Panel01 doppelte IDs entfernt
 - [x] modules.json IDs an HTML angepasst
 - [x] Hilfetexte und Tooltips erweitert, Eingabefelder mit Platzhaltern versehen
-- [ ] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
+- [x] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
 - [ ] Unnötige Platzhalter-Dateien entfernen
-- [ ] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
+- [x] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
 - [ ] GitHub-Workflow test.yml für automatische Prüfungen
-- [ ] README um Abschnitt 'Optimierungsideen' ergänzen
+- [x] README um Abschnitt 'Optimierungsideen' ergänzen
 - [x] Zusätzliche Tooltips für Buttons (Panel01/02/04)
 - [x] Laienhilfe um Cronjob und Tooltip-Hinweis ergänzt
-- [ ] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
+- [x] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
 - [x] Fehlerhandling und Validation verbessert (validation.js, Panel10/11)
 - [x] LAIENHILFE und DOKUMENTATION um Todo-Hinweise erweitert
 - [x] panel07 nutzt common.js, Reset-Funktion ergänzt
@@ -184,10 +185,6 @@
 - [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 - [x] Fehler-&-Hilfe-Panel speichert Fehler in localStorage und bietet Download
 - [x] handleError-Funktion speichert Fehlermeldungen automatisch
-- [ ] Startskript prüft Updates vor dem Start
-- [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
-- [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
-- [ ] Fehler-&-Hilfe-Panel zeigt error_informationen.txt an
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf

--- a/todo.txt
+++ b/todo.txt
@@ -158,14 +158,14 @@
 - [x] Panel01 doppelte IDs entfernt
 - [x] modules.json IDs an HTML angepasst
 - [x] Hilfetexte und Tooltips erweitert, Eingabefelder mit Platzhaltern versehen
-- [ ] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
+- [x] Gemeinsame CSS-Datei (common.css) für Module erstellen und einbinden
 - [ ] Unnötige Platzhalter-Dateien entfernen
-- [ ] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
+- [x] npm-Skript 'selfcheck' anlegen (führt tools/selfcheck.sh aus)
 - [ ] GitHub-Workflow test.yml für automatische Prüfungen
-- [ ] README um Abschnitt 'Optimierungsideen' ergänzen
+- [x] README um Abschnitt 'Optimierungsideen' ergänzen
 - [x] Zusätzliche Tooltips für Buttons (Panel01/02/04)
 - [x] Laienhilfe um Cronjob und Tooltip-Hinweis ergänzt
-- [ ] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
+- [x] LAIENHILFE um weitere Nutzerfreundlichkeits-Tipps erweitern
 - [x] Fehlerhandling und Validation verbessert (validation.js, Panel10/11)
 - [x] LAIENHILFE und DOKUMENTATION um Todo-Hinweise erweitert
 - [x] panel07 nutzt common.js, Reset-Funktion ergänzt


### PR DESCRIPTION
## Summary
- provide a simple `package.json` so `npm run selfcheck` runs `tools/selfcheck.sh`
- add shared stylesheet `modules/common.css` and link it in the HTML
- extend README with an *Optimierungsideen* section
- update LAIENHILFE with npm selfcheck hint and CSS note
- mark related tasks as done in todo lists

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ac701cda8832584d4c8a0cdf48746