### PR TITLE
Improve error handling and update docs

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -48,6 +48,16 @@ Beim Laden erscheint ein kurzes Willkommensfenster. Es schließt sich nach 20 Se
 3. Öffne dann `http://localhost:8000/index-MODULTOOL.html` im Browser (Programm zum Surfen im Internet).
 4. Mit `Strg+C` beendest du den Server wieder.
 
+### Wenn der Start hakt
+1. Rufe `bash tools/start_tool.sh` erneut auf.
+2. Das Skript erkennt fehlende Programme wie `python3` und versucht sie bei Bedarf zu installieren (`sudo apt-get install python3`).
+3. Bei Problemen hilft ein Blick in `/tmp/modultool_server.log` (Textdatei mit Fehlermeldungen).
+4. Oder starte den Selfcheck:
+   ```bash
+   bash tools/selfcheck.sh
+   ```
+   *(Der Selfcheck prüft HTML, JSON und Shell-Skripte auf Fehler.)*
+
 ## Tooltips & Eingabehilfen
 
 - Viele Felder zeigen nun Beispieltexte *(Placeholder = Platzhalter)*.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - [Neues Modul anlegen](#neues-modul-anlegen)
 - [Pakete erstellen (.deb & AppImage)](#-pakete-erstellen-deb--appimage)
 - [Hilfe](#hilfe)
-Zum Starten: `bash tools/start_tool.sh` – überprüft neue Module und öffnet das Tool.
+Zum Starten: `bash tools/start_tool.sh` – überprüft neue Module, versucht fehlende Programme automatisch zu installieren und öffnet das Tool.
 
 Der Selfcheck (`bash tools/selfcheck.sh`) fungiert als einfacher HTML-Fehler-Checker und synchronisiert deine Aufgabenlisten.
 - [Lokaler Testserver](#-lokaler-testserver)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -189,3 +189,4 @@
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 - [x] Startbildschirm schließt automatisch nach 20 Sekunden
+- [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -189,3 +189,4 @@
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 - [x] Startbildschirm schließt automatisch nach 20 Sekunden
+- [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert

--- a/todo.txt
+++ b/todo.txt
@@ -189,3 +189,4 @@
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [ ] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 - [x] Startbildschirm schließt automatisch nach 20 Sekunden
+- [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert

--- a/tools/start_tool.sh
+++ b/tools/start_tool.sh
@@ -2,17 +2,46 @@
 # tools/start_tool.sh - Startet einen lokalen Server und öffnet den Browser
 
 echo "🔄 Suche nach Updates..."
-git fetch >/dev/null 2>&1
+if ! git fetch >/dev/null 2>&1; then
+  echo "⚠️ git fetch fehlgeschlagen. Prüfe deine Internetverbindung."
+fi
 if [ $(git rev-list HEAD..origin/main --count) -gt 0 ]; then
   echo "ℹ️ Es gibt neue Module oder Vorlagen. führe git pull aus."
 fi
 
+check_cmd() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "⚠️ $cmd fehlt. Versuche Installation..."
+    if command -v apt-get >/dev/null 2>&1; then
+      sudo apt-get update && sudo apt-get install -y "$cmd"
+    else
+      echo "Bitte $cmd manuell installieren."
+    fi
+  fi
+}
+
+start_server() {
+  python3 -m http.server >/tmp/modultool_server.log 2>&1 &
+  PID=$!
+  sleep 1
+  if ! kill -0 "$PID" >/dev/null 2>&1; then
+    echo "❌ Serverstart fehlgeschlagen"
+    cat /tmp/modultool_server.log
+    return 1
+  fi
+  return 0
+}
+
 # Standardseite des Tools
 URL="http://localhost:8000/index-MODULTOOL.html"
+check_cmd python3
 echo "🌐 Starte lokalen Server ..."
-python3 -m http.server >/tmp/modultool_server.log 2>&1 &
-PID=$!
-sleep 1
+if ! start_server; then
+  echo "Versuche erneuten Start..."
+  start_server || { echo "Server konnte nicht gestartet werden."; exit 1; }
+fi
+
 if command -v xdg-open >/dev/null; then
   xdg-open "$URL" &
 elif command -v open >/dev/null; then


### PR DESCRIPTION
## Summary
- enhance start_tool.sh with self-healing logic and exitstatus checks
- document recovery steps in LAIENHILFE
- note auto installation in README
- update todo lists

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687acb7e69808325b42059b3e47ddea4