### PR TITLE
Add validation for imports and genre length

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1046,3 +1046,15 @@ Alle Module nutzen nun `modules/common.css`. Hier kannst du das Aussehen zentral
   git tag -a v1.0 -m 'Version 1.0' && git push --tags
   ```
   *(Setzt eine feste Versionsnummer im Repository.)*
+
+- **package.json anlegen (npm init = Projekt starten)**
+  ```bash
+  npm init -y
+  ```
+  *(Erstellt eine Grundeinstellung für dein Projekt. npm merkt sich dort alle Pakete.)*
+
+- **Debounce-Funktion installieren (kurze Wartezeit einbauen)**
+  ```bash
+  npm install lodash.debounce
+  ```
+  *(`lodash.debounce` verzögert eine Funktion, bis kurz Ruhe ist. Praktisch für Suchfelder.)*

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -237,6 +237,28 @@ Dort findest du zuk\u00fcnftig Protokolle (Logs), die dir Hinweise auf Fehler ge
    Das Kommando `echo` (Text ausgeben) schreibt eine Zeile in `test.html`.
 3. Öffne `test.html` im Browser, z. B. mit einem Doppelklick im Dateimanager.
    Nach Eingabe des Namens siehst du die Begrüßung als Text auf der Seite.
+
+## Code aufräumen
+
+1. **Skripte formatieren (Prettier = automatischer Formatierer)**
+   ```bash
+   npx prettier --write .
+   ```
+   *(Ordnet Einrückungen und Leerzeichen.)*
+
+2. **JavaScript prüfen (ESLint = Fehler- und Stilprüfung)**
+   ```bash
+   npx eslint .
+   ```
+   *(Findet Tippfehler und falsche Muster.)*
+
+3. **HTML säubern (DOMPurify = Sanitizer)**
+   ```bash
+   npm install dompurify
+   ```
+   *(Entfernt gefährliche Inhalte bei Importen.)*
+
+Diese Befehle halten deine Module sauber und sicher.
 ## Geplante Erweiterungen
 
 Einige Funktionen sind noch in Arbeit. Die wichtigsten Punkte aus `todo.txt` sind:
@@ -967,3 +989,60 @@ Alle Module nutzen nun `modules/common.css`. Hier kannst du das Aussehen zentral
   git commit -m "Neue Version und Changelog"
   ```
   *(Erhöht die Versionsnummer und ergänzt die Datei `CHANGELOG.md`.)*
+
+## Neue Laien-Tipps
+
+- **Lokalen Server starten (http-server = kleiner Webserver)**
+  ```bash
+  npx http-server
+  ```
+  *(Zeigt die Dateien im Browser unter `http://localhost:8080` an.)*
+
+- **Pakete prüfen und aktualisieren (npm = Paketmanager)**
+  ```bash
+  npm outdated
+  npm update
+  ```
+  *(`npm outdated` listet veraltete Pakete auf, `npm update` bringt sie auf den neuesten Stand.)*
+
+- **CSS automatisch anpassen (Autoprefixer = ergänzt Browser-Vorsilben)**
+  ```bash
+  npx postcss modules/*.css --use autoprefixer -d modules
+  ```
+  *(Erzeugt neue CSS-Dateien mit zusätzlichen Präfixen für ältere Browser.)*
+
+- **Seite mit Lighthouse prüfen (Lighthouse = Analysewerkzeug)**
+  ```bash
+  npx lighthouse http://localhost:8080/index-MODULTOOL.html
+  ```
+  *(Liefert Berichte zu Performance und Barrierefreiheit.)*
+
+- **Node-Version anzeigen (Node.js = JavaScript-Laufzeitumgebung)**
+  ```bash
+  node --version
+  ```
+  *(Zeigt, welche Node-Version installiert ist.)*
+
+- **Sicherheitsprüfung der Pakete (npm audit fix = bekannte Lücken schließen)**
+  ```bash
+  npm audit fix
+  ```
+  *(Aktualisiert automatisch fehlerhafte Abhängigkeiten.)*
+
+- **CSS prüfen (Stylelint = Stilkontrolle)**
+  ```bash
+  npx stylelint "**/*.css"
+  ```
+  *(Findet Probleme im Aussehen der Stylesheets.)*
+
+- **Bilder verkleinern (Imagemin = Bildkomprimierung)**
+  ```bash
+  npx imagemin src/img/* --out-dir=dist/img
+  ```
+  *(Erzeugt kleinere Dateien für schnellere Ladezeiten.)*
+
+- **Version im Git markieren (Tag = Versionsmarkierung)**
+  ```bash
+  git tag -a v1.0 -m 'Version 1.0' && git push --tags
+  ```
+  *(Setzt eine feste Versionsnummer im Repository.)*

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -11,6 +11,10 @@
 - [ ] Wöchentlichen Selfcheck automatisieren (Cronjob)
 - [ ] Release vorbereiten: Selfcheck, README prüfen, Release-Tag erstellen
 - [ ] DEB- und AppImage-Paket bauen
+- [ ] CI/CD-Pipeline einrichten (Lint → Test → Build → Release)
+- [ ] Accessibility-Audit der Panels durchführen und Code aufräumen
+- [ ] Automatische Versionierung und Changelog-Workflow einrichten
+- [ ] JavaScript-Tools auf TypeScript umstellen (Schema-Validierung)
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [x] UX-Layout mit Grid/Flex und ARIA-Fokus verbessern
 - [x] Befehlsreferenz-Modul (panel9) ergänzen
@@ -209,3 +213,55 @@
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [x] panel01 bereinigt (doppelte Elemente entfernt)
 - [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert
+- [x] Doppelte Variablen wie "let genres" entfernen
+- [ ] Einfache Archiv-Buttons einrichten
+- [x] fehlenden Button "importInsertBtn" ergänzen
+- [x] Theme umschalten ohne "null"-Attribut
+- [ ] Fokus nur auf sichtbare Panels zulassen
+- [ ] Logging vereinheitlichen
+- [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
+- [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`
+- [ ] JavaScript-Code pr\u00fcfen mit ESLint (Linting = Fehler- und Stilpr\u00fcfung). Befehl: `npx eslint .`
+- [x] Import-Dateien checken: nur JSON und unter 1 MB (Security = Schutz vor großen oder fremden Dateien). Beispiel im Code: `if(file.size>1000000||!file.name.endsWith('.json')) return alert('Datei zu groß oder kein JSON');`
+- [ ] Versionsnummer in localStorage speichern (Versionierung = Daten einfach aktualisieren). Befehl: `localStorage.setItem('DATA_VERSION','1')`
+- [ ] Suche entprellen (Debounce = kurze Wartezeit vor dem Suchlauf). Befehl: `npm install lodash.debounce`
+- [ ] Dynamische Elemente mit eindeutigen IDs versehen (ID = unverwechselbare Kennung). Beispiel: `elem.id='panel-'+index`
+- [ ] Service Worker einrichten für Offline-Betrieb (PWA = Webapp zum Installieren). Befehl: `npx workbox-cli wizard`
+
+- [ ] Redundante Arrays wie "genres" und "dashboardData" in einem einzigen Objekt `state` sammeln. Befehl: `grep -n "genres" -r`
+- [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
+- [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
+- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+  ```js
+  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  ```
+- [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
+- [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`
+- [ ] Listen per DocumentFragment erneuern (schnelleres Rendering). Befehl:
+  ```js
+  const frag=document.createDocumentFragment();
+  items.forEach(i=>frag.appendChild(i));
+  list.replaceChildren(frag);
+  ```
+- [ ] Skripte aus index-MODULTOOL.html in `app.js` auslagern und mit `<script type="module" defer src="app.js"></script>` einbinden
+- [ ] Zentrale Einstellungen in `config.js` speichern (z.B. Limits, Theme-Liste). Befehl: `nano config.js`
+- [ ] Eine `manifest.json` für die PWA anlegen. Befehl: `npx workbox-cli generateSW`
+- [ ] Einheitlichen Funktionsstil nutzen (Pfeilfunktion = ()=>{} oder function). Automatisch anpassen: `npx eslint . --fix`
+- [ ] Farbwerte vereinheitlichen und Design-Token nutzen. Datei öffnen mit `nano modules/common.css`
+- [ ] Panel-Kopfzeilen einheitlich benennen. Fundstellen anzeigen mit `grep -n head modules/*.html`
+- [ ] Logging zusammenführen (debugLogArr und dashLogArr). Fundstellen suchen: `grep -n dashLogArr -r`
+- [ ] role="region" immer mit aria-labelledby verknüpfen. Beispiel: `<div role="region" aria-labelledby="panel1-head">`
+- [ ] Verschachtelte Buttons vermeiden. Kontrollieren: `grep -n "<button" -r modules`
+- [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
+- [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
+
+- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
+- [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
+- [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).
+- [ ] Pakete auf Aktualität prüfen. Befehl: `npm outdated` (outdated = veraltete Pakete anzeigen).
+- [ ] Alle Pakete aktualisieren. Befehl: `npm update` (update = auf den neuesten Stand bringen).
+- [ ] CSS automatisch mit Autoprefixer erweitern. Befehl: `npx postcss modules/*.css --use autoprefixer -d modules` (Autoprefixer = Browser-Präfixe ergänzen).
+- [ ] Web-App mit Lighthouse testen. Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html` (Lighthouse = Analyse für Performance und Barrierefreiheit).
+- [ ] Lokalen Server ohne Python starten. Befehl: `npx http-server` (http-server = einfacher Entwicklungsserver).

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -217,7 +217,7 @@
 - [ ] Einfache Archiv-Buttons einrichten
 - [x] fehlenden Button "importInsertBtn" ergänzen
 - [x] Theme umschalten ohne "null"-Attribut
-- [ ] Fokus nur auf sichtbare Panels zulassen
+- [x] Fokus nur auf sichtbare Panels zulassen
 - [ ] Logging vereinheitlichen
 - [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
 - [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -463,24 +463,33 @@ let fokusMode = 0;
 fokusSelect.onchange = function() { switchFokus(Number(fokusSelect.value)); };
 function switchFokus(mode) {
   fokusMode = mode;
+  if (mode !== 0) {
+    const target = document.getElementById('panel' + mode);
+    if (target && target.style.display === 'none') {
+      fokusSelect.value = '0';
+      logDbg('Panel im Fokus ausgeblendet.');
+      return;
+    }
+  }
   for (let i = 1; i <= 11; ++i) {
     const panel = document.getElementById('panel' + i);
     if (mode === 0) {
-      panel.style.display = '';
+      const box=document.getElementById('mod'+i+'box');
+      panel.style.display = box && !box.checked ? 'none' : '';
       panel.classList.remove('fokus');
-      panel.setAttribute('aria-hidden','false');
+      panel.setAttribute('aria-hidden',panel.style.display==='none'?'true':'false');
     } else {
       const on = (i === mode);
       panel.style.display = on ? '' : 'none';
-      if (on) panel.classList.add('fokus'); else panel.classList.remove('fokus');
+      panel.classList.toggle('fokus', on);
       panel.setAttribute('aria-hidden', on ? 'false' : 'true');
     }
   }
   fokusResetBtn.style.display = (mode !== 0) ? '' : 'none';
   fokusSelect.value = String(mode);
   if (mode !== 0) {
-    const pf = document.getElementById('panel'+mode);
-    if (pf) { pf.focus(); }
+    const pf = document.getElementById('panel' + mode);
+    if (pf) pf.focus();
   }
 }
 /* ====== Farbschema & Initialisierung ====== */

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -410,6 +410,7 @@
         <button onclick="triggerModuleImport()">Import starten</button>
         <div class="import-status" id="importStatus" role="status" aria-live="polite"></div>
         <pre id="importPreview" style="max-height:110px;overflow:auto;background:#252c2e;color:#bbb;padding:.4em .7em;border-radius:.6em;display:none;margin:.5em 0 0 0;"></pre>
+        <button id="importInsertBtn" onclick="insertImportedPanel()" style="display:none;">Einfügen</button>
         <div class="input-help">Du kannst HTML- oder JS-Moduldateien importieren. Beispiel: <code>custom_module.js</code> oder <code>toolpanel.html</code>. Fehler werden hier angezeigt.</div>
       </section>
       <section class="mod-panel" id="panel7" tabindex="0">
@@ -495,7 +496,11 @@ function renderThemeBtnGroup() {
   ).join('');
 }
 function setTheme(t) {
-  document.body.setAttribute('data-theme', t==="default"?null:t);
+  if (t === 'default') {
+    document.body.removeAttribute('data-theme');
+  } else {
+    document.body.setAttribute('data-theme', t);
+  }
   curTheme = t;
   localStorage.setItem('themePppoppi', t);
   renderThemeBtnGroup();
@@ -534,9 +539,6 @@ let dashboardData = [];
 let tmplArchiv = [];
 let notesData = '';
 const WEIGHT_KEY = 'genreWeights_vGRIDSB';
-let genres = [];
-let dashboardData = [];
-let tmplArchiv = [];
 let genreWeights = {};
 let searchTerm = '';
 /* Logging und Selfcheck */
@@ -585,6 +587,11 @@ let importModuleContent = '';
 document.getElementById('importModuleFile').addEventListener('change', function(e){
   const file = e.target.files[0];
   if(!file) return;
+  if(file.size>1000000 || !/\.(html|js|json)$/i.test(file.name)){
+    document.getElementById('importStatus').textContent='Datei zu groß oder falscher Typ';
+    logErr('Ungültige Datei: '+file.name);
+    return;
+  }
   const reader = new FileReader();
   reader.onload = function(ev){
     importModuleContent = ev.target.result;

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -36,11 +36,16 @@ const output=document.getElementById('random-output');
 const log=document.getElementById('log');
 const statusEl=document.getElementById('status');
 const STORAGE_KEY='genres';
+function hasTooLong(arr){
+  return arr.some(g=>g.length>24);
+}
 function getList(){
   return input.value.split(',').map(s=>s.trim()).filter(Boolean);
 }
 function saveList(){
-  const list=[...new Set(getList())].sort((a,b)=>a.localeCompare(b));
+  const raw=getList();
+  if(hasTooLong(raw)){showStatus(statusEl,'Max 24 Zeichen pro Genre');return [];} 
+  const list=[...new Set(raw)].sort((a,b)=>a.localeCompare(b));
   try{
     localStorage.setItem(STORAGE_KEY,JSON.stringify(list));
     input.value=list.join(', ');
@@ -69,6 +74,7 @@ saveBtn.addEventListener('click',()=>{
 });
 randomBtn.addEventListener('click',()=>{
   const list=getList();
+  if(hasTooLong(list)){showStatus(statusEl,'Max 24 Zeichen pro Genre');return;}
   if(list.length===0){showStatus(statusEl,'Liste ist leer');return;}
   const choice=list[Math.floor(Math.random()*list.length)];
   output.textContent=choice;

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -52,31 +52,26 @@ function render(){
     btn.className='tmpl-btn';
     btn.textContent=t.title;
     btn.title='Text kopieren';
-    btn.onclick=()=>{navigator.clipboard.writeText(t.text);};
-    const rm=document.createElement('button');
-    rm.className='remove-btn';
-    rm.textContent='✖';
-    rm.title='Textbaustein löschen';
-    rm.onclick=()=>{arr.splice(i,1);saveTemplates(arr);render();};
-    btn.onclick=()=>{
+    btn.addEventListener('click',()=>{
       navigator.clipboard.writeText(t.text).then(()=>{
         btn.classList.add('copied');
         setTimeout(()=>btn.classList.remove('copied'),800);
         addDashboard('Snippet: '+t.title);
         showStatus(statusEl,'Kopiert: '+t.title);
       });
-    };
+    });
     const rm=document.createElement('button');
     rm.className='remove-btn';
     rm.textContent='✖';
-    rm.onclick=()=>{
+    rm.title='Textbaustein löschen';
+    rm.addEventListener('click',()=>{
       arr.splice(i,1);
       saveTemplates(arr);
       render();
       showStatus(statusEl,'Gelöscht: '+t.title);
-    };
+    });
     const wrapper=document.createElement('div');
-    wrapper.appendChild(btn);wrapper.appendChild(rm);
+    wrapper.append(btn, rm);
     listDiv.appendChild(wrapper);
   });
 }

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -11,6 +11,10 @@
 - [ ] Wöchentlichen Selfcheck automatisieren (Cronjob)
 - [ ] Release vorbereiten: Selfcheck, README prüfen, Release-Tag erstellen
 - [ ] DEB- und AppImage-Paket bauen
+- [ ] CI/CD-Pipeline einrichten (Lint → Test → Build → Release)
+- [ ] Accessibility-Audit der Panels durchführen und Code aufräumen
+- [ ] Automatische Versionierung und Changelog-Workflow einrichten
+- [ ] JavaScript-Tools auf TypeScript umstellen (Schema-Validierung)
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [x] UX-Layout mit Grid/Flex und ARIA-Fokus verbessern
 - [x] Befehlsreferenz-Modul (panel9) ergänzen
@@ -209,3 +213,55 @@
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [x] panel01 bereinigt (doppelte Elemente entfernt)
 - [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert
+- [x] Doppelte Variablen wie "let genres" entfernen
+- [ ] Einfache Archiv-Buttons einrichten
+- [x] fehlenden Button "importInsertBtn" ergänzen
+- [x] Theme umschalten ohne "null"-Attribut
+- [ ] Fokus nur auf sichtbare Panels zulassen
+- [ ] Logging vereinheitlichen
+- [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
+- [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`
+- [ ] JavaScript-Code pr\u00fcfen mit ESLint (Linting = Fehler- und Stilpr\u00fcfung). Befehl: `npx eslint .`
+- [x] Import-Dateien checken: nur JSON und unter 1 MB (Security = Schutz vor großen oder fremden Dateien). Beispiel im Code: `if(file.size>1000000||!file.name.endsWith('.json')) return alert('Datei zu groß oder kein JSON');`
+- [ ] Versionsnummer in localStorage speichern (Versionierung = Daten einfach aktualisieren). Befehl: `localStorage.setItem('DATA_VERSION','1')`
+- [ ] Suche entprellen (Debounce = kurze Wartezeit vor dem Suchlauf). Befehl: `npm install lodash.debounce`
+- [ ] Dynamische Elemente mit eindeutigen IDs versehen (ID = unverwechselbare Kennung). Beispiel: `elem.id='panel-'+index`
+- [ ] Service Worker einrichten für Offline-Betrieb (PWA = Webapp zum Installieren). Befehl: `npx workbox-cli wizard`
+
+- [ ] Redundante Arrays wie "genres" und "dashboardData" in einem einzigen Objekt `state` sammeln. Befehl: `grep -n "genres" -r`
+- [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
+- [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
+- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+  ```js
+  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  ```
+- [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
+- [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`
+- [ ] Listen per DocumentFragment erneuern (schnelleres Rendering). Befehl:
+  ```js
+  const frag=document.createDocumentFragment();
+  items.forEach(i=>frag.appendChild(i));
+  list.replaceChildren(frag);
+  ```
+- [ ] Skripte aus index-MODULTOOL.html in `app.js` auslagern und mit `<script type="module" defer src="app.js"></script>` einbinden
+- [ ] Zentrale Einstellungen in `config.js` speichern (z.B. Limits, Theme-Liste). Befehl: `nano config.js`
+- [ ] Eine `manifest.json` für die PWA anlegen. Befehl: `npx workbox-cli generateSW`
+- [ ] Einheitlichen Funktionsstil nutzen (Pfeilfunktion = ()=>{} oder function). Automatisch anpassen: `npx eslint . --fix`
+- [ ] Farbwerte vereinheitlichen und Design-Token nutzen. Datei öffnen mit `nano modules/common.css`
+- [ ] Panel-Kopfzeilen einheitlich benennen. Fundstellen anzeigen mit `grep -n head modules/*.html`
+- [ ] Logging zusammenführen (debugLogArr und dashLogArr). Fundstellen suchen: `grep -n dashLogArr -r`
+- [ ] role="region" immer mit aria-labelledby verknüpfen. Beispiel: `<div role="region" aria-labelledby="panel1-head">`
+- [ ] Verschachtelte Buttons vermeiden. Kontrollieren: `grep -n "<button" -r modules`
+- [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
+- [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
+
+- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
+- [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
+- [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).
+- [ ] Pakete auf Aktualität prüfen. Befehl: `npm outdated` (outdated = veraltete Pakete anzeigen).
+- [ ] Alle Pakete aktualisieren. Befehl: `npm update` (update = auf den neuesten Stand bringen).
+- [ ] CSS automatisch mit Autoprefixer erweitern. Befehl: `npx postcss modules/*.css --use autoprefixer -d modules` (Autoprefixer = Browser-Präfixe ergänzen).
+- [ ] Web-App mit Lighthouse testen. Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html` (Lighthouse = Analyse für Performance und Barrierefreiheit).
+- [ ] Lokalen Server ohne Python starten. Befehl: `npx http-server` (http-server = einfacher Entwicklungsserver).

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -217,7 +217,7 @@
 - [ ] Einfache Archiv-Buttons einrichten
 - [x] fehlenden Button "importInsertBtn" ergänzen
 - [x] Theme umschalten ohne "null"-Attribut
-- [ ] Fokus nur auf sichtbare Panels zulassen
+- [x] Fokus nur auf sichtbare Panels zulassen
 - [ ] Logging vereinheitlichen
 - [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
 - [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`

--- a/todo.txt
+++ b/todo.txt
@@ -217,7 +217,7 @@
 - [ ] Einfache Archiv-Buttons einrichten
 - [x] fehlenden Button "importInsertBtn" ergänzen
 - [x] Theme umschalten ohne "null"-Attribut
-- [ ] Fokus nur auf sichtbare Panels zulassen
+- [x] Fokus nur auf sichtbare Panels zulassen
 - [ ] Logging vereinheitlichen
 - [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
 - [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`

--- a/todo.txt
+++ b/todo.txt
@@ -213,3 +213,55 @@
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [x] panel01 bereinigt (doppelte Elemente entfernt)
 - [x] Startskript um Selbstheilung & Exitstatus-Prüfung erweitert
+- [x] Doppelte Variablen wie "let genres" entfernen
+- [ ] Einfache Archiv-Buttons einrichten
+- [x] fehlenden Button "importInsertBtn" ergänzen
+- [x] Theme umschalten ohne "null"-Attribut
+- [ ] Fokus nur auf sichtbare Panels zulassen
+- [ ] Logging vereinheitlichen
+- [ ] DOMPurify einsetzen, um HTML zu s\u00e4ubern (Sanitizing = gef\u00e4hrliche Inhalte entfernen). Befehl: `npm install dompurify`
+- [ ] Code-Formatierung mit Prettier (Formatierer = ordnet Einr\u00fcckungen und Leerzeichen). Befehl: `npx prettier --write .`
+- [ ] JavaScript-Code pr\u00fcfen mit ESLint (Linting = Fehler- und Stilpr\u00fcfung). Befehl: `npx eslint .`
+- [x] Import-Dateien checken: nur JSON und unter 1 MB (Security = Schutz vor großen oder fremden Dateien). Beispiel im Code: `if(file.size>1000000||!file.name.endsWith('.json')) return alert('Datei zu groß oder kein JSON');`
+- [ ] Versionsnummer in localStorage speichern (Versionierung = Daten einfach aktualisieren). Befehl: `localStorage.setItem('DATA_VERSION','1')`
+- [ ] Suche entprellen (Debounce = kurze Wartezeit vor dem Suchlauf). Befehl: `npm install lodash.debounce`
+- [ ] Dynamische Elemente mit eindeutigen IDs versehen (ID = unverwechselbare Kennung). Beispiel: `elem.id='panel-'+index`
+- [ ] Service Worker einrichten für Offline-Betrieb (PWA = Webapp zum Installieren). Befehl: `npx workbox-cli wizard`
+
+- [ ] Redundante Arrays wie "genres" und "dashboardData" in einem einzigen Objekt `state` sammeln. Befehl: `grep -n "genres" -r`
+- [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
+- [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
+- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+  ```js
+  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  ```
+- [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
+- [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`
+- [ ] Listen per DocumentFragment erneuern (schnelleres Rendering). Befehl:
+  ```js
+  const frag=document.createDocumentFragment();
+  items.forEach(i=>frag.appendChild(i));
+  list.replaceChildren(frag);
+  ```
+- [ ] Skripte aus index-MODULTOOL.html in `app.js` auslagern und mit `<script type="module" defer src="app.js"></script>` einbinden
+- [ ] Zentrale Einstellungen in `config.js` speichern (z.B. Limits, Theme-Liste). Befehl: `nano config.js`
+- [ ] Eine `manifest.json` für die PWA anlegen. Befehl: `npx workbox-cli generateSW`
+- [ ] Einheitlichen Funktionsstil nutzen (Pfeilfunktion = ()=>{} oder function). Automatisch anpassen: `npx eslint . --fix`
+- [ ] Farbwerte vereinheitlichen und Design-Token nutzen. Datei öffnen mit `nano modules/common.css`
+- [ ] Panel-Kopfzeilen einheitlich benennen. Fundstellen anzeigen mit `grep -n head modules/*.html`
+- [ ] Logging zusammenführen (debugLogArr und dashLogArr). Fundstellen suchen: `grep -n dashLogArr -r`
+- [ ] role="region" immer mit aria-labelledby verknüpfen. Beispiel: `<div role="region" aria-labelledby="panel1-head">`
+- [ ] Verschachtelte Buttons vermeiden. Kontrollieren: `grep -n "<button" -r modules`
+- [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
+- [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
+
+- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
+- [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
+- [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).
+- [ ] Pakete auf Aktualität prüfen. Befehl: `npm outdated` (outdated = veraltete Pakete anzeigen).
+- [ ] Alle Pakete aktualisieren. Befehl: `npm update` (update = auf den neuesten Stand bringen).
+- [ ] CSS automatisch mit Autoprefixer erweitern. Befehl: `npx postcss modules/*.css --use autoprefixer -d modules` (Autoprefixer = Browser-Präfixe ergänzen).
+- [ ] Web-App mit Lighthouse testen. Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html` (Lighthouse = Analyse für Performance und Barrierefreiheit).
+- [ ] Lokalen Server ohne Python starten. Befehl: `npx http-server` (http-server = einfacher Entwicklungsserver).


### PR DESCRIPTION
## Summary
- teach novices about version checks, audits and more
- block oversized or unknown import files
- restrict genre names to 24 characters
- mark finished tasks in all todo files

## Testing
- `bash tools/selfcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ada708fec83258ea06c7c19c168da