### PR TITLE
Improve modules fetch and docs

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1158,15 +1158,27 @@ Alle Module nutzen nun `modules/common.css`. Hier kannst du das Aussehen zentral
   Jedes Modul hat jetzt einen kleinen *Fokus*-Knopf. Ein Klick blendet nur dieses Panel ein.
   Im Fokus siehst du oben im Panel den Knopf **Zurück**, der wieder die normale Übersicht zeigt.
 
+
 - **Dateien sicher laden (fetch = Dateien abrufen)**
   ```js
-  fetch('modules.json').then(r => {
-    if (!r.ok) throw new Error(r.status); // r.ok prüft auf Erfolg
-    return r.json();
-  });
+  async function loadRegisteredPanels(){
+    const res = await fetch('modules.json');
+    if(!res.ok){
+      if(res.status === 404) throw new Error('Modulliste nicht gefunden (404)');
+      throw new Error('HTTP ' + res.status);
+    }
+    const cfg = await res.json(); // prüft auf gültiges JSON
+    cfg.modules.forEach(m => loadPanel(m.id));
+  }
   ```
-  *(Wirft eine Fehlermeldung, wenn die Datei nicht geladen werden konnte.)*
+  *(Bricht mit einer klaren Meldung ab, wenn die Datei fehlt oder fehlerhaft ist.)*
 
+- **modules.json reparieren**
+  ```bash
+  ls -l modules.json   # Prüfen, ob die Datei existiert
+  nano modules.json    # Inhalt öffnen und Klammern prüfen
+  ```
+  *(Nach dem Speichern Seite neu laden, um die Module zu laden.)*
 - **Automatisches Backup im Browser (setInterval = Zeitsteuerung)**
   ```js
   setInterval(() => {

--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -868,6 +868,14 @@ Mit der Zeit sammeln sich leere Dateien oder doppelte Einträge an. So bringst d
   ```
   *(Öffnet das Modul im Editor. "nano" ist ein einfacher Texteditor im Terminal.)*
 
+- **Layout & Zoom steuern**
+  ```bash
+  F11             # Vollbildmodus
+  Strg+Mausrad    # Zoom
+  Strg+0          # Normalgröße
+  ```
+  *(Im Fokus-Modus füllt ein gewähltes Panel den ganzen Bildschirm.)*
+
 
 ## Todo-Liste immer aktualisieren
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ python3 -m http.server
 - Sichere Zwischenstände mit `git stash` (temporärer Speicher).
 - Erstelle neue Module mit `node tools/create_module.js modulID "Titel"`.
 
+## 🖥 Layout & Zoom
+- Über das Dropdown **Fokus-Modus** blendest du alle anderen Panels aus und siehst ein Modul bildschirmfüllend.
+- Halte **Strg** gedrückt und rolle mit dem Mausrad, um hinein- oder herauszuzoomen (Browser-Zoom). Mit **Strg+0** stellst du die Normalgröße wieder her.
+- Das Tool passt sich nach dem Zoomen automatisch an (Auto-Scale). Kein Neuladen nötig.
+
 ## Hilfe
 
 Ausführliche Tipps findest du in der Datei [LAIENHILFE.md](LAIENHILFE.md). Dort stehen alle Schritte in einfacher Sprache mit Beispielen.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ python3 -m http.server
 - Über das Dropdown **Fokus-Modus** blendest du alle anderen Panels aus und siehst ein Modul bildschirmfüllend.
 - Halte **Strg** gedrückt und rolle mit dem Mausrad, um hinein- oder herauszuzoomen (Browser-Zoom). Mit **Strg+0** stellst du die Normalgröße wieder her.
 - Das Tool passt sich nach dem Zoomen automatisch an (Auto-Scale). Kein Neuladen nötig.
+## ❓ Fehlerbehebung modules.json
+Wenn die Meldung *"Modulliste nicht gefunden (404)"* erscheint, kontrolliere im Terminal:
+```bash
+ls -l modules.json
+```
+Fehlt die Datei, lege sie neu an und trage deine Module ein.
+
+Bei *"modules.json defekt"* öffne die Datei und prüfe die Klammern:
+```bash
+nano modules.json
+```
+Speichere mit **Strg+O**, beende mit **Strg+X** und lade die Seite neu.
 
 ## Hilfe
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -50,9 +50,9 @@
 - [ ] Info-Manager für eigene Befehle anlegen
 - [ ] Zitaten-Modul mit Notizfeld umsetzen
 - [ ] Interaktiven Modulbaukasten erstellen
-- Anleitung zum Selbstcheck im README ergänzt
-- modules.json erstellt (enthält angemeldete Panels)
-- README um Hinweis zu modules.json ergänzt
+- [x] Anleitung zum Selbstcheck im README ergänzt
+- [x] modules.json erstellt (enthält angemeldete Panels)
+- [x] README um Hinweis zu modules.json ergänzt
 - Nach jeder Änderung: `bash tools/selfcheck.sh` ausführen (Selbsttest)
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
@@ -139,7 +139,15 @@
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
 - [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
-  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  async function loadRegisteredPanels(){
+    const res = await fetch('modules.json');
+    if(!res.ok){
+      if(res.status === 404) throw new Error('Modulliste nicht gefunden (404)');
+      throw new Error('HTTP '+res.status);
+    }
+    const cfg = await res.json();
+    cfg.modules.forEach(m => loadPanel(m.id));
+  }
   ```
 - [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
 - [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -14,6 +14,16 @@
 - [ ] Accessibility-Audit der Panels durchführen und Code aufräumen
 - [ ] Automatische Versionierung und Changelog-Workflow einrichten
 - [ ] JavaScript-Tools auf TypeScript umstellen (Schema-Validierung)
+- [ ] Eingaben prüfen (Input-Sanitierung) für IDs und Pfade
+- [ ] Alle Konfigs mit Schema validieren (JSON Schema/Zod)
+- [ ] Eigene Fehlerklassen definieren
+- [ ] Zentralen Error-Handler einrichten
+- [ ] Fehlermeldungen nutzerfreundlich formulieren
+- [ ] Automatischen Rollback bei Abbruch einbauen
+- [ ] Wiederholen-Funktion nach Fehler anbieten
+- [ ] Logging mit Zeitstempel im UI anzeigen
+- [ ] Log-Download-Button einfügen
+- [ ] Standard-Vorlagen und Beispiel-Module bereitstellen
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [ ] Zufallsmodi mit Profilgewichtung implementieren
 - [x] Logging ins Dashboard einbauen
@@ -127,7 +137,7 @@
 - [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
-- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+- [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
   fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
   ```

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -1083,15 +1083,23 @@ function loadPanel(id, cb){
     .then(html=>{document.getElementById(id).innerHTML = html; if(cb) cb();})
     .catch(e=>logErr('Panel-Load '+id+': '+e));
 }
-function loadRegisteredPanels(){
-  fetch('modules.json')
-    .then(r=>{if(!r.ok) throw new Error(r.status); return r.json();})
-    .then(cfg=>{
-      cfg.modules.forEach(m=>{
-        if(m.id==='panel8') loadPanel(m.id, renderWeightList); else loadPanel(m.id);
-      });
-    })
-    .catch(e=>logErr('Module-Liste: '+e));
+async function loadRegisteredPanels(){
+  try {
+    const res = await fetch('modules.json');
+    if(!res.ok){
+      if(res.status===404) throw new Error('Modulliste nicht gefunden (404) – ggf. deploy vergessen.');
+      throw new Error('HTTP '+res.status);
+    }
+    let cfg;
+    try { cfg = await res.json(); }
+    catch(err){ throw new Error('modules.json defekt: '+err.message); }
+    cfg.modules.forEach(m=>{
+      if(m.id==='panel8') loadPanel(m.id, renderWeightList); else loadPanel(m.id);
+    });
+  } catch(e){
+    logErr('Module-Liste: '+e.message);
+    alert(e.message);
+  }
 }
 loadRegisteredPanels();
 // Intro-Overlay nach 20 Sekunden automatisch ausblenden

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -50,9 +50,9 @@
 - [ ] Info-Manager für eigene Befehle anlegen
 - [ ] Zitaten-Modul mit Notizfeld umsetzen
 - [ ] Interaktiven Modulbaukasten erstellen
-- Anleitung zum Selbstcheck im README ergänzt
-- modules.json erstellt (enthält angemeldete Panels)
-- README um Hinweis zu modules.json ergänzt
+- [x] Anleitung zum Selbstcheck im README ergänzt
+- [x] modules.json erstellt (enthält angemeldete Panels)
+- [x] README um Hinweis zu modules.json ergänzt
 - Nach jeder Änderung: `bash tools/selfcheck.sh` ausführen (Selbsttest)
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
@@ -139,7 +139,15 @@
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
 - [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
-  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  async function loadRegisteredPanels(){
+    const res = await fetch('modules.json');
+    if(!res.ok){
+      if(res.status === 404) throw new Error('Modulliste nicht gefunden (404)');
+      throw new Error('HTTP '+res.status);
+    }
+    const cfg = await res.json();
+    cfg.modules.forEach(m => loadPanel(m.id));
+  }
   ```
 - [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
 - [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -14,6 +14,16 @@
 - [ ] Accessibility-Audit der Panels durchführen und Code aufräumen
 - [ ] Automatische Versionierung und Changelog-Workflow einrichten
 - [ ] JavaScript-Tools auf TypeScript umstellen (Schema-Validierung)
+- [ ] Eingaben prüfen (Input-Sanitierung) für IDs und Pfade
+- [ ] Alle Konfigs mit Schema validieren (JSON Schema/Zod)
+- [ ] Eigene Fehlerklassen definieren
+- [ ] Zentralen Error-Handler einrichten
+- [ ] Fehlermeldungen nutzerfreundlich formulieren
+- [ ] Automatischen Rollback bei Abbruch einbauen
+- [ ] Wiederholen-Funktion nach Fehler anbieten
+- [ ] Logging mit Zeitstempel im UI anzeigen
+- [ ] Log-Download-Button einfügen
+- [ ] Standard-Vorlagen und Beispiel-Module bereitstellen
 # Liste mit sich aus Entwicklung ergebenden weiteren noch zu erfüllenden Aufgaben
 - [ ] Zufallsmodi mit Profilgewichtung implementieren
 - [x] Logging ins Dashboard einbauen
@@ -127,7 +137,7 @@
 - [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
-- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+- [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
   fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
   ```

--- a/todo.txt
+++ b/todo.txt
@@ -137,7 +137,7 @@
 - [x] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Genre-Eingaben strikt auf 24 Zeichen begrenzen. Beispiel: `if(input.value.length > 24) return alert("Max 24 Zeichen");`
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
-- [ ] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
+- [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
   fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
   ```

--- a/todo.txt
+++ b/todo.txt
@@ -50,9 +50,9 @@
 - [ ] Info-Manager für eigene Befehle anlegen
 - [ ] Zitaten-Modul mit Notizfeld umsetzen
 - [ ] Interaktiven Modulbaukasten erstellen
-- Anleitung zum Selbstcheck im README ergänzt
-- modules.json erstellt (enthält angemeldete Panels)
-- README um Hinweis zu modules.json ergänzt
+- [x] Anleitung zum Selbstcheck im README ergänzt
+- [x] modules.json erstellt (enthält angemeldete Panels)
+- [x] README um Hinweis zu modules.json ergänzt
 - Nach jeder Änderung: `bash tools/selfcheck.sh` ausführen (Selbsttest)
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
@@ -139,7 +139,15 @@
 - [ ] Gewichtete Zufallsauswahl vor dem Anzeigen laden. Befehl: `window.addEventListener("DOMContentLoaded", initWeights);`
 - [x] fetch("modules.json") mit Fehlermeldung absichern. Beispiel:
   ```js
-  fetch("modules.json").then(r=>{ if(!r.ok) throw new Error(r.status); return r.json(); });
+  async function loadRegisteredPanels(){
+    const res = await fetch('modules.json');
+    if(!res.ok){
+      if(res.status === 404) throw new Error('Modulliste nicht gefunden (404)');
+      throw new Error('HTTP '+res.status);
+    }
+    const cfg = await res.json();
+    cfg.modules.forEach(m => loadPanel(m.id));
+  }
   ```
 - [ ] Logeinträge im localStorage speichern (Ringpuffer = nur die letzten 50). Befehl: `localStorage.setItem("logs", JSON.stringify(logs.slice(-50)))`
 - [ ] Selfcheck-Fehler direkt mit Lösung verlinken. Befehl: `node tools/map_errors.js`


### PR DESCRIPTION
## Summary
- add error handling for `modules.json` loading
- document layout and zoom controls
- include layout & zoom tip in LAIENHILFE
- mark related todo item done and sync lists

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687afe4fcc0c83259b6a60a47e135028