### PR TITLE
Add Node version helper

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1089,11 +1089,11 @@ Alle Module nutzen nun `modules/common.css`. Hier kannst du das Aussehen zentral
   ```
   *(Liefert Berichte zu Performance und Barrierefreiheit.)*
 
-- **Node-Version anzeigen (Node.js = JavaScript-Laufzeitumgebung)**
-  ```bash
-  node --version
-  ```
-  *(Zeigt, welche Node-Version installiert ist.)*
+ - **Node-Version anzeigen (Node.js = JavaScript-Laufzeitumgebung)**
+   ```bash
+   bash tools/node_version.sh
+   ```
+   *(Führt `node --version` aus und zeigt die installierte Version.)*
 
 - **Sicherheitsprüfung der Pakete (npm audit fix = bekannte Lücken schließen)**
   ```bash

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -173,7 +173,7 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
-- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+ - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
 - [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -173,7 +173,7 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
-- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+ - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
 - [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).

--- a/todo.txt
+++ b/todo.txt
@@ -173,7 +173,7 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
-- [ ] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+ - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
 - [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).

--- a/tools/node_version.sh
+++ b/tools/node_version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# tools/node_version.sh - zeigt die installierte Node.js Version an
+
+if command -v node >/dev/null 2>&1; then
+  echo "Installierte Node-Version:"
+  node --version
+else
+  echo "Node.js ist nicht installiert."
+fi


### PR DESCRIPTION
## Summary
- provide `tools/node_version.sh` for a quick Node.js version check
- explain the new command in `LAIENHILFE.md`
- mark "Node-Version anzeigen" as done in todo lists

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b227a7aac8325b9a0a4a02087c047