### PR TITLE
Add color contrast module

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1423,3 +1423,8 @@ python3 -m http.server
 
 - **Einheitliche Knöpfe nutzen (class = Klasse)**
   Füge jedem `<button>` das Attribut `class="btn"` hinzu. So greifen die zentralen Regeln aus `modules/common.css`.
+
+- **Farbkontrast testen (Kontrast = Unterschied von Vorder- und Hintergrund)**
+  1. `bash tools/start_tool.sh` – startet Server und Browser.
+  2. `http://localhost:8000/modules/contrast_optimizer.html` öffnen.
+  3. Farben wählen und auf **Kontrast prüfen** klicken. Ab 4.5 gilt der Text als gut lesbar.

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -35,7 +35,7 @@
 - [x] Erinnerung an ungespeicherte Änderungen beim Beenden integrieren
 - [ ] Persönlichen Startbildschirm mit Favoriten-Modulen erstellen
 - [ ] Automatische Validierung jedes Moduls vor Aktivierung
-- [ ] Farbkontrast-Optimierung nach WCAG umsetzen
+- [x] Farbkontrast-Optimierung nach WCAG umsetzen
 - [ ] Fokusmodus: 1 Modul fullscreen, andere minimiert
 - [ ] Tooltip-Akademie beim ersten Start anzeigen
 - [ ] Modul-Querverlinkung zwischen Panels ermöglichen

--- a/modules.json
+++ b/modules.json
@@ -84,6 +84,11 @@
       "id": "unsaved",
       "title": "Warnung vor ungespeicherten Änderungen",
       "file": "modules/unsaved_changes_warning.html"
+    },
+    {
+      "id": "contrast",
+      "title": "Kontrast-Optimierer",
+      "file": "modules/contrast_optimizer.html"
     }
   ]
 }

--- a/modules/contrast_optimizer.html
+++ b/modules/contrast_optimizer.html
@@ -1,2 +1,60 @@
 <!DOCTYPE html>
-<div>Placeholder for contrast_optimizer.html</div>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Kontrast-Optimierer</title>
+<style>
+  #contrastOpt{display:grid;gap:.5rem;max-width:340px;margin:auto;font-family:var(--font-family,sans-serif);}
+  label{display:flex;flex-direction:column;}
+  input[type="color"]{width:100%;height:2rem;border:none;}
+  #sampleText{padding:1rem;border-radius:var(--btn-radius,.5rem);}
+  #result{font-weight:bold;min-height:1.2em;}
+  button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
+</style>
+</head>
+<body>
+<div id="contrastOpt">
+  <h2>Kontrast-Optimierer</h2>
+  <label>Vordergrundfarbe
+    <input id="fgColor" type="color" value="#000000">
+  </label>
+  <label>Hintergrundfarbe
+    <input id="bgColor" type="color" value="#ffffff">
+  </label>
+  <button id="checkBtn">Kontrast prüfen</button>
+  <div id="sampleText">Beispieltext</div>
+  <div id="result" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+import { showStatus } from './common.js';
+const fg=document.getElementById('fgColor');
+const bg=document.getElementById('bgColor');
+const checkBtn=document.getElementById('checkBtn');
+const sample=document.getElementById('sampleText');
+const result=document.getElementById('result');
+function luminance(r,g,b){
+  const a=[r,g,b].map(v=>{v/=255;return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4);});
+  return a[0]*0.2126+a[1]*0.7152+a[2]*0.0722;
+}
+function contrast(hex1,hex2){
+  const c1=hex1.match(/\w{2}/g).map(h=>parseInt(h,16));
+  const c2=hex2.match(/\w{2}/g).map(h=>parseInt(h,16));
+  const l1=luminance(c1[0],c1[1],c1[2]);
+  const l2=luminance(c2[0],c2[1],c2[2]);
+  return (Math.max(l1,l2)+0.05)/(Math.min(l1,l2)+0.05);
+}
+function updateSample(){
+  sample.style.color=fg.value;
+  sample.style.backgroundColor=bg.value;
+}
+checkBtn.addEventListener('click',()=>{
+  updateSample();
+  const ratio=contrast(fg.value,bg.value);
+  const ok=ratio>=4.5?'✅ ausreichend':'❌ zu gering';
+  showStatus(result,'Kontrast: '+ratio.toFixed(2)+' – '+ok);
+});
+updateSample();
+</script>
+</body>
+</html>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -35,7 +35,7 @@
 - [x] Erinnerung an ungespeicherte Änderungen beim Beenden integrieren
 - [ ] Persönlichen Startbildschirm mit Favoriten-Modulen erstellen
 - [ ] Automatische Validierung jedes Moduls vor Aktivierung
-- [ ] Farbkontrast-Optimierung nach WCAG umsetzen
+- [x] Farbkontrast-Optimierung nach WCAG umsetzen
 - [ ] Fokusmodus: 1 Modul fullscreen, andere minimiert
 - [ ] Tooltip-Akademie beim ersten Start anzeigen
 - [ ] Modul-Querverlinkung zwischen Panels ermöglichen

--- a/todo.txt
+++ b/todo.txt
@@ -35,7 +35,7 @@
 - [x] Erinnerung an ungespeicherte Änderungen beim Beenden integrieren
 - [ ] Persönlichen Startbildschirm mit Favoriten-Modulen erstellen
 - [ ] Automatische Validierung jedes Moduls vor Aktivierung
-- [ ] Farbkontrast-Optimierung nach WCAG umsetzen
+- [x] Farbkontrast-Optimierung nach WCAG umsetzen
 - [ ] Fokusmodus: 1 Modul fullscreen, andere minimiert
 - [ ] Tooltip-Akademie beim ersten Start anzeigen
 - [ ] Modul-Querverlinkung zwischen Panels ermöglichen


### PR DESCRIPTION
## Summary
- implement `contrast_optimizer.html`
- register new module in `modules.json`
- document how to test color contrast in *LAIENHILFE*
- mark contrast task done in todo list

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b2698a5748325bf76bf52ceb03a8d