### PR TITLE
Add npm start script and update docs

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1432,3 +1432,22 @@ python3 -m http.server
   1. Drücke `Strg+Shift+I` im Browser, um die Entwicklerwerkzeuge zu öffnen.
   2. Klicke auf das Handy-Icon (Device Toolbar).
   3. Ändere die Breite und beobachte das Layout.
+
+## Updates und Versionen
+
+Um das Tool aktuell zu halten, gibt es zwei einfache Befehle:
+
+```bash
+npm start
+```
+
+*Startet den lokalen Server über das Skript `start_tool.sh`.*
+
+```bash
+npm run sync
+```
+
+*Aktualisiert die Liste der Modul-Versionen über `lib/update_manager.js`.*
+
+Nach dem Aktualisieren kannst du `npm update` ausführen, um alle Pakete auf den
+neuesten Stand zu bringen.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - [Neues Modul anlegen](#neues-modul-anlegen)
 - [Pakete erstellen (.deb & AppImage)](#-pakete-erstellen-deb--appimage)
 - [Hilfe](#hilfe)
-Zum Starten: `bash tools/start_tool.sh` – überprüft neue Module, versucht fehlende Programme automatisch zu installieren und öffnet das Tool.
+Zum Starten: `npm start` oder `bash tools/start_tool.sh` – beide Varianten prüfen neue Module, versuchen fehlende Programme automatisch zu installieren und öffnen das Tool.
 
 Der Selfcheck (`bash tools/selfcheck.sh`) fungiert als einfacher HTML-Fehler-Checker und synchronisiert deine Aufgabenlisten.
 - [Lokaler Testserver](#-lokaler-testserver)
@@ -122,7 +122,7 @@ Voraussetzung sind die Programme `dpkg-deb` und `appimagetool`. Falls sie fehlen
 1. `git clone <REPO>` (Repository, Sammlung der Dateien)
 2. `cd modultool`
 3. `bash tools/selfcheck.sh`
-4. `bash tools/start_tool.sh`
+4. `npm start`  # startet das Tool
 5. Browser öffnet sich automatisch
 
 ## 🌐 Lokaler Testserver
@@ -135,6 +135,7 @@ python3 -m http.server
 Öffne danach `http://localhost:8000` im Browser. So lassen sich alle Module testen, ohne Dateien doppelt anzuklicken.
 ## ♻ Optimierungsideen
 - Nutze `npm run selfcheck` (führt das Prüfskript aus).
+- Aktualisiere die Modulversionen mit `npm run sync`.
 - Sichere Zwischenstände mit `git stash` (temporärer Speicher).
 - Erstelle neue Module mit `node tools/create_module.js modulID "Titel"`.
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -200,3 +200,7 @@
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
 - [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
+- [x] Startskript über npm start verfügbar
+- [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt
+- [x] README mit Hinweisen auf npm start und npm run sync
+- [x] Modulversionen mit npm run sync aktualisiert

--- a/module_versions.json
+++ b/module_versions.json
@@ -15,5 +15,6 @@
   "panel13": "1.0",
   "quotes": "1.1",
   "todo": "1.1",
-  "unsaved": "1.0"
+  "unsaved": "1.0",
+  "contrast": "1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "lint": "npm run selfcheck",
     "test": "echo 'Noch keine Tests'",
     "build": "tsc",
-    "release": "npm version patch"
+    "release": "npm version patch",
+    "start": "bash tools/start_tool.sh",
+    "sync": "node lib/update_manager.js sync"
   },
   "devDependencies": {
     "@types/node": "^24.0.14",

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -200,3 +200,7 @@
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
 - [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
+- [x] Startskript über npm start verfügbar
+- [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt
+- [x] README mit Hinweisen auf npm start und npm run sync
+- [x] Modulversionen mit npm run sync aktualisiert

--- a/todo.txt
+++ b/todo.txt
@@ -200,3 +200,7 @@
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
 - [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
+- [x] Startskript über npm start verfügbar
+- [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt
+- [x] README mit Hinweisen auf npm start und npm run sync
+- [x] Modulversionen mit npm run sync aktualisiert


### PR DESCRIPTION
## Summary
- add start and sync scripts to package.json
- document `npm start` and `npm run sync` usage
- add new "Updates und Versionen" section in LAIENHILFE
- update module_versions via `npm run sync`
- refresh todo lists

## Testing
- `bash tools/selfcheck.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b327c2d2083258b7389c95a4d35a5