### PR TITLE
Update error info instructions

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -378,6 +378,12 @@ sudo npm install -g htmlhint
    ```
    *("nano" ist ein einfacher Texteditor im Terminal.)*
 4. Seite neu laden (**F5**), um die Änderungen zu sehen.
+5. Trage deine Hinweise in `error_informationen.txt` ein, zum Beispiel:
+   ```
+   Modul nicht gefunden -> modules.json pruefen
+   Selfcheck starten -> bash tools/selfcheck.sh
+   ```
+   *(Die Datei sammelt einfache Fehlernotizen.)*
 
 ## Textbaustein-Modul benutzen
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -95,6 +95,7 @@
 
 - [ ] Fehler-Tipps direkt im Tool anzeigen (Tooltip = kurzer Hinweis).
 - [ ] Fehler-Logdatei automatisch pflegen (logs/error.log).
+- [ ] Fehlerhinweise in error_informationen.txt ergänzen
 - [ ] Release-Endspurt: Offene Punkte laut README (Undo/Redo, ZIP-Backup, Filter/Favoriten, Scrollsync/Projektordner)
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [ ] Einfache Archiv-Buttons einrichten

--- a/error_informationen.txt
+++ b/error_informationen.txt
@@ -1,1 +1,5 @@
-
+# Tipps bei Fehlermeldungen
+- Browser-Konsole mit F12 öffnen und "Console" prüfen.
+- Selfcheck ausführen: `bash tools/selfcheck.sh`
+- HTML-Prüfer installieren: `npm install -g htmlhint`
+- Fehlende Dateien hier notieren, z.B. `modules/panel_xy.html`

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -95,6 +95,7 @@
 
 - [ ] Fehler-Tipps direkt im Tool anzeigen (Tooltip = kurzer Hinweis).
 - [ ] Fehler-Logdatei automatisch pflegen (logs/error.log).
+- [ ] Fehlerhinweise in error_informationen.txt ergänzen
 - [ ] Release-Endspurt: Offene Punkte laut README (Undo/Redo, ZIP-Backup, Filter/Favoriten, Scrollsync/Projektordner)
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [ ] Einfache Archiv-Buttons einrichten

--- a/todo.txt
+++ b/todo.txt
@@ -95,6 +95,7 @@
 
 - [ ] Fehler-Tipps direkt im Tool anzeigen (Tooltip = kurzer Hinweis).
 - [ ] Fehler-Logdatei automatisch pflegen (logs/error.log).
+- [ ] Fehlerhinweise in error_informationen.txt ergänzen
 - [ ] Release-Endspurt: Offene Punkte laut README (Undo/Redo, ZIP-Backup, Filter/Favoriten, Scrollsync/Projektordner)
 - [ ] Vor dem Release bash tools/selfcheck.sh ausfuehren und Releasenotizen im README ergaenzen
 - [ ] Einfache Archiv-Buttons einrichten


### PR DESCRIPTION
## Summary
- expand instructions in LAIENHILFE on how to use `error_informationen.txt`
- provide default tips in `error_informationen.txt`
- add todo item for adding error hints
- sync todo files

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b3266dd308325a3ad4b35f25f2953