### PR TITLE
Add favorites start screen

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1599,3 +1599,15 @@ GitHub Actions sind automatische Abläufe auf GitHub. Sie prüfen den Code nach 
   bash tools/manage_projects.sh delete Test # löscht "Test"
   ```
   *(Mit dem Skript kannst du Projekte erstellen, auswählen, löschen und das aktuelle anzeigen.)*
+
+- **Favoriten-Startseite öffnen**
+  ```bash
+  xdg-open modules/favorites_start_screen.html
+  ```
+  *(Zeigt deine markierten Lieblings-Module im Browser an. "xdg-open" öffnet eine Datei mit dem Standardprogramm.)*
+
+- **Favoriten zurücksetzen (localStorage = Speicher im Browser)**
+  ```bash
+  node -e "localStorage.clear()"
+  ```
+  *(Entfernt gespeicherte Favoriten und andere Einstellungen.)*

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -1278,7 +1278,7 @@ setTimeout(hideIntro, 20000);
 document.addEventListener('keyup', e => { if(e.key === 'Escape') hideIntro(); });
 function hideIntro(){
   const el = document.getElementById('introOverlay');
-  if(el) el.style.display='none';
+  if(el) el.remove();
 }
 function openHelp(){
   window.open('LAIENHILFE.md','_blank');

--- a/modules.json
+++ b/modules.json
@@ -99,6 +99,11 @@
       "id": "zipbackup",
       "title": "ZIP-Backup",
       "file": "modules/zip_backup.html"
+    },
+    {
+      "id": "favstart",
+      "title": "Favoriten-Start",
+      "file": "modules/favorites_start_screen.html"
     }
   ]
 }

--- a/modules/favorites_start_screen.html
+++ b/modules/favorites_start_screen.html
@@ -1,2 +1,53 @@
 <!DOCTYPE html>
-<div>Placeholder for favorites_start_screen.html</div>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Favoriten-Start</title>
+  <style>
+    #favStart{display:grid;gap:0.5rem;max-width:340px;margin:auto;font-family:var(--font-family,sans-serif);}
+    button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
+    .fav-list{list-style:none;padding:0;margin:0;}
+    .fav-list li{margin:.3rem 0;}
+  </style>
+</head>
+<body>
+<div id="favStart">
+  <h2>Favoriten</h2>
+  <ul id="favList" class="fav-list"></ul>
+</div>
+<script type="module">
+import { loadJSON } from './common.js';
+const FAV_KEY='modFavorites_v1';
+const list=document.getElementById('favList');
+async function loadModules(){
+  try{
+    const res=await fetch('modules.json');
+    if(!res.ok) throw new Error(res.status);
+    const data=await res.json();
+    return data.modules||[];
+  }catch(e){
+    console.warn('Modules konnten nicht geladen werden',e);
+    return [];
+  }
+}
+function render(mods,favs){
+  list.innerHTML='';
+  favs.forEach(id=>{
+    const mod=mods.find(m=>m.id===id);
+    if(!mod) return;
+    const li=document.createElement('li');
+    const btn=document.createElement('button');
+    btn.textContent=mod.title;
+    btn.addEventListener('click',()=>window.open(mod.file,'_blank'));
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+(async()=>{
+  const mods=await loadModules();
+  const favs=loadJSON(FAV_KEY,[]);
+  render(mods,favs);
+})();
+</script>
+</body>
+</html>

--- a/todo.txt
+++ b/todo.txt
@@ -34,7 +34,7 @@
 - [x] Dokumentation aktualisieren (README, AGENTS)
 - [x] Fehlende Dateien und Ordner mit Platzhaltern anlegen
 - [x] Erinnerung an ungespeicherte Änderungen beim Beenden integrieren
-- [ ] Persönlichen Startbildschirm mit Favoriten-Modulen erstellen
+- [x] Persönlichen Startbildschirm mit Favoriten-Modulen erstellen
 - [x] Bugfix: Startbildschirm schließt per X-Button
 - [ ] Automatische Validierung jedes Moduls vor Aktivierung
 - [x] Farbkontrast-Optimierung nach WCAG umsetzen


### PR DESCRIPTION
## Summary
- add simple favorites start page
- register the new module in `modules.json`
- guarantee the intro overlay is closable by removing it from the DOM
- extend the help file with tips for handling favorites
- update `todo.txt`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b560078648325b35649c1de40e849