### PR TITLE
Improve start script usage

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -35,9 +35,14 @@ So behältst du jederzeit die Kontrolle über deine Dateien.
 ## Tool starten
 
 Am einfachsten nutzt du das Startskript. Es erledigt alles für dich.
+Mit `-h` oder `--help` zeigt es eine kleine Hilfe an.
 
 ```bash
 bash tools/start_tool.sh
+```
+Oder ohne Browserstart:
+```bash
+bash tools/start_tool.sh --no-browser
 ```
 
 Damit startet ein Server (kleines Programm zur Bereitstellung der Dateien) und öffnet die Seite automatisch im Browser.
@@ -64,6 +69,8 @@ Beim Laden erscheint ein kurzes Willkommensfenster. Es schließt sich nach 20 Se
 - Halte die Maus über ein Eingabefeld, um einen **Tooltip** (kurzer Hinweis) zu sehen.
 - Beispiel: Im Modul *Persona-Switcher* weist das Namensfeld mit "Name des Profils" auf den Zweck hin.
 - Diese Tipps helfen, schneller zu verstehen, was eingetragen werden soll.
+- Für das Startskript kannst du `bash tools/start_tool.sh -h` eingeben. Das
+  zeigt eine kurze Erklärung der Optionen *(Option = zusätzliche Einstellung)*.
 
 ## Eigene Module erstellen
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Entwickelt für kreative Subkulturen, Performerinnen, Künstlerinnen und Content
 - [Neues Modul anlegen](#neues-modul-anlegen)
 - [Pakete erstellen (.deb & AppImage)](#-pakete-erstellen-deb--appimage)
 - [Hilfe](#hilfe)
-Zum Starten: `npm start` oder `bash tools/start_tool.sh` – beide Varianten prüfen neue Module, versuchen fehlende Programme automatisch zu installieren und öffnen das Tool.
+Zum Starten: `npm start` oder `bash tools/start_tool.sh`. Mit `-h` zeigt das Skript eine Hilfe, `--no-browser` startet nur den Server. Beide Varianten prüfen neue Module, versuchen fehlende Programme automatisch zu installieren und öffnen das Tool.
 
 Der Selfcheck (`bash tools/selfcheck.sh`) fungiert als einfacher HTML-Fehler-Checker und synchronisiert deine Aufgabenlisten.
 - [Lokaler Testserver](#-lokaler-testserver)

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -95,6 +95,7 @@
 
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] Startskript prüft Updates vor dem Start
+- [x] Hilfeoption (-h) und Browser-Auswahl (--no-browser) im Startskript
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -95,6 +95,7 @@
 
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] Startskript prüft Updates vor dem Start
+- [x] Hilfeoption (-h) und Browser-Auswahl (--no-browser) im Startskript
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 

--- a/todo.txt
+++ b/todo.txt
@@ -95,6 +95,7 @@
 
 - [ ] Startskript prüft Updates vor dem Start
 - [ ] Startskript prüft Updates vor dem Start
+- [x] Hilfeoption (-h) und Browser-Auswahl (--no-browser) im Startskript
 - [ ] README mit Inhaltsverzeichnis und Hilfe-Link ergänzen
 - [x] selfcheck.sh synchronisiert todo-Dateien nach Lauf
 

--- a/tools/start_tool.sh
+++ b/tools/start_tool.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 # tools/start_tool.sh - Startet einen lokalen Server und öffnet den Browser
 
+show_help() {
+  cat <<EOF
+Nutzung: bash tools/start_tool.sh [OPTION]
+  -h, --help        zeigt diese kurze Hilfe
+  -n, --no-browser  startet ohne Browser
+EOF
+}
+
+NO_BROWSER=0
+for arg in "$@"; do
+  case $arg in
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    -n|--no-browser)
+      NO_BROWSER=1
+      ;;
+  esac
+done
+
 echo "🔄 Suche nach Updates..."
 if ! git fetch >/dev/null 2>&1; then
   echo "⚠️ git fetch fehlgeschlagen. Prüfe deine Internetverbindung."
@@ -42,12 +63,16 @@ if ! start_server; then
   start_server || { echo "Server konnte nicht gestartet werden."; exit 1; }
 fi
 
-if command -v xdg-open >/dev/null; then
-  xdg-open "$URL" &
-elif command -v open >/dev/null; then
-  open "$URL" &
+if [ "$NO_BROWSER" -eq 0 ]; then
+  if command -v xdg-open >/dev/null; then
+    xdg-open "$URL" &
+  elif command -v open >/dev/null; then
+    open "$URL" &
+  else
+    echo "Bitte Browser manuell öffnen und $URL aufrufen"
+  fi
 else
-  echo "Bitte Browser manuell öffnen und $URL aufrufen"
+  echo "Browserstart übersprungen (--no-browser)"
 fi
 echo "👍 Server läuft (Beenden mit Strg+C)"
 wait $PID


### PR DESCRIPTION
## Summary
- add `-h` and `--no-browser` options to `start_tool.sh`
- document new options in README and LAIENHILFE
- add bullet about new help in Tooltips section
- note task done in `todo.txt` and synced copies

## Testing
- `npx mocha`
- `npm run selfcheck`

------
https://chatgpt.com/codex/tasks/task_e_687b576f3a7c8325a0c2a0dfafaf0421