### PR TITLE
Add security audit script with selfcheck integration

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1176,9 +1176,9 @@ Folgende Aufgaben sind noch offen:
 
 - **Sicherheitsprüfung der Pakete (npm audit fix = bekannte Lücken schließen)**
   ```bash
-  npm audit fix
+  npm run audit
   ```
-  *(Aktualisiert automatisch fehlerhafte Abhängigkeiten.)*
+  *(Führt `npm audit fix` aus und schließt bekannte Schwachstellen.)*
 
 - **CSS prüfen (Stylelint = Stilkontrolle)**
   ```bash

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ python3 -m http.server
 - Starte die neuen Unit-Tests mit `npm test`.
 - Bei jedem `git push` laufen GitHub Actions (automatische Abläufe) und prüfen den Code mit `npm run lint` und `npm test`.
 - Aktualisiere die Modulversionen mit `npm run sync`.
+- Führe eine Sicherheitsprüfung aus mit `npm run audit`.
 - Sichere Zwischenstände mit `git stash` (temporärer Speicher).
 - Erstelle ein ZIP-Backup mit `bash tools/zip_backup.sh`.
 - Erstelle neue Module mit `node tools/create_module.js modulID "Titel"`.

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -181,8 +181,8 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
- - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
-- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [x] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
 - [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "release": "npm version patch",
     "start": "bash tools/start_tool.sh",
-    "sync": "node lib/update_manager.js sync"
+    "sync": "node lib/update_manager.js sync",
+    "audit": "bash tools/security_check.sh"
   },
   "devDependencies": {
     "@types/node": "^24.0.14",

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -181,8 +181,8 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
- - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
-- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [x] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
 - [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).

--- a/todo.txt
+++ b/todo.txt
@@ -181,8 +181,8 @@
 - [ ] Kontrast im hellen Theme optimieren. Farbe in `modules/common.css` anpassen (`nano modules/common.css`)
 - [ ] Fokus-Ring-Farbe an Rahmen angleichen. Variable `--focus-ring` in `modules/common.css` definieren
 
- - [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
-- [ ] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
+- [x] Node-Version anzeigen. Befehl: `node --version` (Node.js = JavaScript-Laufzeitumgebung).
+- [x] Pakete automatisch auf Sicherheitslücken prüfen. Befehl: `npm audit fix` (Security-Check = bekannte Schwachstellen schließen).
 - [ ] CSS mit Stylelint prüfen. Befehl: `npx stylelint "**/*.css"` (Stylelint = CSS-Stilprüfer).
 - [ ] Bilder verkleinern mit Imagemin. Befehl: `npx imagemin src/img/* --out-dir=dist/img` (Bildkomprimierung = kleinere Dateigröße).
 - [ ] Git-Tag für Release setzen. Befehl: `git tag -a v1.0 -m 'Version 1.0' && git push --tags` (Tag = Versionsmarkierung im Repository).

--- a/tools/security_check.sh
+++ b/tools/security_check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# tools/security_check.sh - führt eine Sicherheitsprüfung der Node-Pakete durch
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm ist nicht installiert. Bitte erst Node.js und npm einrichten."
+  exit 1
+fi
+
+echo "🔍 Starte Sicherheitsprüfung der Pakete..."
+if npm audit fix; then
+  echo "✅ Sicherheitsprüfung abgeschlossen."
+else
+  echo "⚠️ npm audit fix konnte nicht alle Probleme lösen."
+fi

--- a/tools/selfcheck.sh
+++ b/tools/selfcheck.sh
@@ -106,5 +106,12 @@ if [ -n "$conflicts" ]; then
   echo "❌ Unaufgelöste Konflikte gefunden:" && echo "$conflicts"
 fi
 
+# ========== Sicherheitsprüfung ==========
+if [ -x tools/security_check.sh ]; then
+  bash tools/security_check.sh
+else
+  echo "⚠️ Sicherheitsprüfung übersprungen (tools/security_check.sh fehlt)"
+fi
+
 # ========== Abschluss ==========
 echo "✅ Selfcheck abgeschlossen. Alles bereit!"


### PR DESCRIPTION
## Summary
- add `tools/security_check.sh` to run `npm audit fix`
- wire the security check into the selfcheck
- add `npm run audit` script in package.json
- document security check in README and LAIENHILFE
- mark TODO as done and sync placeholder copies

## Testing
- `bash tools/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b66e8bf1c8325ab1796d348139e0f