### PR TITLE
Update buttons with aria-labels and add help tips

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1804,3 +1804,30 @@ Die Tipps erscheinen nur beim ersten Aufruf.
    ```
    *(LocalStorage = Speicher im Browser für Einstellungen.)*
 
+
+## Weitere Laienvorschläge (Zusatz 2)
+
+- **Tool automatisch prüfen (Linting = Codekontrolle)**
+  ```bash
+  npm run lint
+  ```
+  *(Sucht nach typischen Programmierfehlern.)*
+
+- **Lokalen Testserver starten (Server = stellt Dateien bereit)**
+  ```bash
+  npx http-server
+  ```
+  *(Zeigt die Seite unter http://localhost:8080.)*
+
+- **Fehlerprotokoll ansehen (Logfile = Liste der Meldungen)**
+  ```bash
+  cat logs/error.log
+  ```
+  *(Zeigt gespeicherte Fehlermeldungen.)*
+
+- **Pakete aktualisieren (Update = auf den neuesten Stand bringen)**
+  ```bash
+  npm update
+  ```
+  *(Lädt aktuelle Versionen aller Abhängigkeiten.)*
+

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -203,10 +203,10 @@
 
 - [ ] Kontrastwerte nach WCAG pruefen (Kontrast = Unterschied zwischen Vorder- und Hintergrund). Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html`
 - [x] Einheitliche Schriftgroesse per CSS-Variable `--base-font` in index-MODULTOOL.html setzen (base-font = Grundschrift).
-- [ ] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
+- [x] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
 - [x] Grid-Layout mit `grid-template-columns: repeat(auto-fit, minmax(320px,1fr))` in modules/common.css erweitern (Grid = Raster zur Anordnung).
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
-- [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
+- [x] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
 - [x] Startskript über npm start verfügbar
 - [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt

--- a/modules/auto_backup.html
+++ b/modules/auto_backup.html
@@ -13,9 +13,9 @@
 <body>
 <div id="autoBackup">
   <h2>Auto-Backup</h2>
-  <button id="startBackupBtn">Backup starten</button>
-  <button id="stopBackupBtn">Backup stoppen</button>
-  <button id="restoreBackupBtn">Backup laden</button>
+  <button class="btn" id="startBackupBtn" aria-label="Backup starten">Backup starten</button>
+  <button class="btn" id="stopBackupBtn" aria-label="Backup stoppen">Backup stoppen</button>
+  <button class="btn" id="restoreBackupBtn" aria-label="Backup laden">Backup laden</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/contrast_optimizer.html
+++ b/modules/contrast_optimizer.html
@@ -22,7 +22,7 @@
   <label>Hintergrundfarbe
     <input id="bgColor" type="color" value="#ffffff">
   </label>
-  <button id="checkBtn">Kontrast prüfen</button>
+  <button class="btn" id="checkBtn" aria-label="Kontrast prüfen">Kontrast prüfen</button>
   <div id="sampleText">Beispieltext</div>
   <div id="result" role="status" aria-live="polite"></div>
 </div>

--- a/modules/direct_exporter.html
+++ b/modules/direct_exporter.html
@@ -18,8 +18,8 @@
   <input id="file-name" type="text" placeholder="beispiel" aria-label="Dateiname" />
   <label for="text-input">Inhalt:</label>
   <textarea id="text-input" aria-label="Text"></textarea>
-  <button id="save-txt">Als Text speichern</button>
-  <button id="save-json">Als JSON speichern</button>
+  <button class="btn" id="save-txt" aria-label="Als Text speichern">Als Text speichern</button>
+  <button class="btn" id="save-json" aria-label="Als JSON speichern">Als JSON speichern</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/info_manager.html
+++ b/modules/info_manager.html
@@ -13,7 +13,7 @@
 <div id="infoMgr">
   <h2>Info-Manager</h2>
   <textarea id="infoText" placeholder="Eigene Befehle hier notieren"></textarea>
-  <button id="saveInfoBtn">Speichern</button>
+  <button class="btn" id="saveInfoBtn" aria-label="Speichern">Speichern</button>
   <div id="msg" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/module_builder.html
+++ b/modules/module_builder.html
@@ -19,7 +19,7 @@
   <input id="modId" type="text" placeholder="z.B. panel15" />
   <label for="modTitle">Titel:</label>
   <input id="modTitle" type="text" placeholder="Mein Modul" />
-  <button id="createBtn">Vorlage erzeugen</button>
+  <button class="btn" id="createBtn" aria-label="Vorlage erzeugen">Vorlage erzeugen</button>
   <textarea id="result" aria-label="HTML-Vorlage"></textarea>
 </div>
 <script type="module">
@@ -48,7 +48,7 @@ document.getElementById('createBtn').addEventListener('click',()=>{
   <input id="id-input" aria-label="Modul-ID">
   <label for="title-input">Titel:</label>
   <input id="title-input" aria-label="Modul-Titel">
-  <button id="create-btn">HTML anzeigen</button>
+  <button class="btn" id="create-btn" aria-label="HTML anzeigen">HTML anzeigen</button>
   <textarea id="output" aria-label="Modul-Code"></textarea>
 </div>
 <script type="module">

--- a/modules/panel01.html
+++ b/modules/panel01.html
@@ -18,11 +18,11 @@
   <h2>Genre-Liste & Zufall</h2>
   <label for="genre-input">Genres (durch Kommas trennen):</label>
   <textarea id="genre-input" aria-label="Genre-Liste" placeholder="z.B. Rock, Pop" autofocus></textarea>
-  <button id="save-btn" aria-label="Liste speichern">Speichern</button>
-  <button id="random-btn" aria-label="Zufällig auswählen">Zufall</button>
-  <button id="copy-btn" aria-label="Ergebnis kopieren">Kopieren</button>
-  <button id="undo-btn" aria-label="Letzten Schritt rückgängig machen">Undo</button>
-  <button id="redo-btn" aria-label="Rückgängig gemachten Schritt wiederholen">Redo</button>
+  <button class="btn" id="save-btn" aria-label="Liste speichern" aria-label="Speichern">Speichern</button>
+  <button class="btn" id="random-btn" aria-label="Zufällig auswählen" aria-label="Zufall">Zufall</button>
+  <button class="btn" id="copy-btn" aria-label="Ergebnis kopieren" aria-label="Kopieren">Kopieren</button>
+  <button class="btn" id="undo-btn" aria-label="Letzten Schritt rückgängig machen" aria-label="Undo">Undo</button>
+  <button class="btn" id="redo-btn" aria-label="Rückgängig gemachten Schritt wiederholen" aria-label="Redo">Redo</button>
   <div id="random-output" role="status" aria-live="polite"></div>
   <ul id="log"></ul>
   <div id="status" role="status" aria-live="polite"></div>

--- a/modules/panel02.html
+++ b/modules/panel02.html
@@ -20,8 +20,8 @@
   <label for="tmpl-text">Text:</label>
   <textarea id="tmpl-text" rows="2" aria-label="Textvorlage"
             placeholder="Inhalt hier eingeben" title="Text für die Vorlage" required></textarea>
-  <button id="add-btn" title="Vorlage speichern">Hinzufügen</button>
-  <button id="update-btn" style="display:none">Aktualisieren</button>
+  <button class="btn" id="add-btn" title="Vorlage speichern" aria-label="Hinzufügen">Hinzufügen</button>
+  <button class="btn" id="update-btn" style="display:none" aria-label="Aktualisieren">Aktualisieren</button>
   <ul id="tmpl-list"></ul>
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/modules/panel03.html
+++ b/modules/panel03.html
@@ -18,15 +18,15 @@
   <div>
   <label for="moduleSelect">Modul öffnen:</label>
   <select id="moduleSelect" title="Modul aus der Liste wählen"></select>
-  <button id="openModuleBtn" title="Gewähltes Modul im neuen Tab anzeigen">Öffnen</button>
+  <button class="btn" id="openModuleBtn" title="Gewähltes Modul im neuen Tab anzeigen" aria-label="Öffnen">Öffnen</button>
   <div class="input-help">Wähle ein Modul und klicke auf Öffnen. Es erscheint in einem neuen Tab.</div>
   </div>
   <h3>Nächste Termine</h3>
   <ul id="next-list"></ul>
   <div id="current-time" role="status" aria-live="polite"></div>
   <ul id="log-list" aria-label="Verlauf"></ul>
-  <button id="clear-btn" title="Verlauf komplett leeren">Alles löschen</button>
-  <button id="export-btn" title="Verlauf als Textdatei speichern">Exportieren</button>
+  <button class="btn" id="clear-btn" title="Verlauf komplett leeren" aria-label="Alles löschen">Alles löschen</button>
+  <button class="btn" id="export-btn" title="Verlauf als Textdatei speichern" aria-label="Exportieren">Exportieren</button>
 </div>
 <script type="module">
 const STORAGE_KEY='dashboardLog';

--- a/modules/panel04.html
+++ b/modules/panel04.html
@@ -24,7 +24,7 @@
   <label for="text-input">Text:</label>
   <textarea id="text-input" aria-label="Template-Text"
             placeholder="Text hier eingeben" title="Inhalt des Textbausteins"></textarea>
-  <button id="add-btn" title="Textbaustein speichern">Hinzufügen</button>
+  <button class="btn" id="add-btn" title="Textbaustein speichern" aria-label="Hinzufügen">Hinzufügen</button>
   <div id="template-list"></div>
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/modules/panel05.html
+++ b/modules/panel05.html
@@ -20,13 +20,13 @@
   <label for="persona-desc">Beschreibung:</label>
   <textarea id="persona-desc" aria-label="Persona-Beschreibung"
             placeholder="Stil, Stimme, Eigenheiten" title="Kurzbeschreibung"></textarea>
-  <button id="add-btn">Profil speichern</button>
+  <button class="btn" id="add-btn" aria-label="Profil speichern">Profil speichern</button>
   <label for="persona-select">Profil wählen:</label>
   <select id="persona-select">
     <option value="" disabled selected>Profil wählen</option>
   </select>
-  <button id="copy-btn">Kopieren</button>
-  <button id="delete-btn">Profil löschen</button>
+  <button class="btn" id="copy-btn" aria-label="Kopieren">Kopieren</button>
+  <button class="btn" id="delete-btn" aria-label="Profil löschen">Profil löschen</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/panel06.html
+++ b/modules/panel06.html
@@ -18,10 +18,10 @@
   <h2>Story-Sampler</h2>
   <label for="story-input">Story-Ideen (je Zeile eine):</label>
   <textarea id="story-input" aria-label="Story-Ideen"></textarea>
-  <button id="save-btn">Speichern</button>
-  <button id="random-btn">Zufall</button>
-  <button id="copy-btn">Kopieren</button>
-  <button id="clear-btn">Liste löschen</button>
+  <button class="btn" id="save-btn" aria-label="Speichern">Speichern</button>
+  <button class="btn" id="random-btn" aria-label="Zufall">Zufall</button>
+  <button class="btn" id="copy-btn" aria-label="Kopieren">Kopieren</button>
+  <button class="btn" id="clear-btn" aria-label="Liste löschen">Liste löschen</button>
   <div id="random-output" role="status" aria-live="polite"></div>
   <ul id="log"></ul>
   <div id="status" role="status" aria-live="polite"></div>

--- a/modules/panel07.html
+++ b/modules/panel07.html
@@ -18,8 +18,8 @@
   <input id="title-input" aria-label="Cover-Titel">
   <label for="color-input">Farbe:</label>
   <input type="color" id="color-input" value="#ff6699" aria-label="Farbe wählen">
-  <button id="save-btn">Speichern</button>
-  <button id="reset-btn">Zurücksetzen</button>
+  <button class="btn" id="save-btn" aria-label="Speichern">Speichern</button>
+  <button class="btn" id="reset-btn" aria-label="Zurücksetzen">Zurücksetzen</button>
   <div id="preview"></div>
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/modules/panel08.html
+++ b/modules/panel08.html
@@ -19,7 +19,7 @@
     <option value="light">Hell</option>
     <option value="blue">Blau</option>
   </select>
-  <button id="apply-btn">Übernehmen</button>
+  <button class="btn" id="apply-btn" aria-label="Übernehmen">Übernehmen</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/panel09.html
+++ b/modules/panel09.html
@@ -30,7 +30,7 @@
   </select>
   <label for="path-input">Standardpfad:</label>
   <input id="path-input" placeholder="./data" aria-label="Standardpfad" title="Ordner für Importe und Exporte">
-  <button id="save-btn">Speichern</button>
+  <button class="btn" id="save-btn" aria-label="Speichern">Speichern</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/panel11.html
+++ b/modules/panel11.html
@@ -16,7 +16,7 @@
   <input type="date" id="dateInput">
   <label for="entryText">Eintrag:</label>
   <input type="text" id="entryText" placeholder="Kurzbeschreibung">
-  <button id="addBtn">Speichern</button>
+  <button class="btn" id="addBtn" aria-label="Speichern">Speichern</button>
   <div id="monthHeader"></div>
   <ul id="day-list"></ul>
   <div id="dayStatus" role="status" aria-live="polite"></div>

--- a/modules/panel12.html
+++ b/modules/panel12.html
@@ -19,10 +19,10 @@
   <input id="wiki-title" aria-label="Titel">
   <label for="wiki-content">Text:</label>
   <textarea id="wiki-content" aria-label="Wiki-Text"></textarea>
-  <button id="save-wiki">Speichern</button>
+  <button class="btn" id="save-wiki" aria-label="Speichern">Speichern</button>
   <label for="wiki-select">Gespeicherte Seiten:</label>
   <select id="wiki-select"></select>
-  <button id="load-wiki">Laden</button>
+  <button class="btn" id="load-wiki" aria-label="Laden">Laden</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/panel13.html
+++ b/modules/panel13.html
@@ -19,10 +19,10 @@
   <input id="blog-title" aria-label="Titel">
   <label for="blog-content">Artikel:</label>
   <textarea id="blog-content" aria-label="Artikeltext"></textarea>
-  <button id="save-blog">Speichern</button>
+  <button class="btn" id="save-blog" aria-label="Speichern">Speichern</button>
   <label for="blog-select">Gespeicherte Artikel:</label>
   <select id="blog-select"></select>
-  <button id="load-blog">Laden</button>
+  <button class="btn" id="load-blog" aria-label="Laden">Laden</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/panel14.html
+++ b/modules/panel14.html
@@ -18,8 +18,8 @@
       .then(r => r.text())
       .then(t => { document.getElementById("errorInfo").textContent = t || "Keine Fehlerhinweise vorhanden."; });
   </script>
-  <button id="saveErrorsBtn">Fehler speichern</button>
-  <button id="clearErrorsBtn">Fehler löschen</button>
+  <button class="btn" id="saveErrorsBtn" aria-label="Fehler speichern">Fehler speichern</button>
+  <button class="btn" id="clearErrorsBtn" aria-label="Fehler löschen">Fehler löschen</button>
   <script type="module">
     import { handleError } from '../validation.js';
     const info=document.getElementById('errorInfo');

--- a/modules/quote_manager.html
+++ b/modules/quote_manager.html
@@ -22,8 +22,8 @@
   <label for="note-input">Notiz (optional):</label>
   <input id="note-input" type="text" aria-label="Notiz" placeholder="Anmerkung">
   <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
-    <button id="add-btn" title="Eintrag speichern">Hinzufügen</button>
-    <button id="export-btn" title="Alle Zitate exportieren">Exportieren</button>
+    <button class="btn" id="add-btn" title="Eintrag speichern" aria-label="Hinzufügen">Hinzufügen</button>
+    <button class="btn" id="export-btn" title="Alle Zitate exportieren" aria-label="Exportieren">Exportieren</button>
   </div>
   <ul id="quote-list"></ul>
   <div id="status" role="status" aria-live="polite"></div>

--- a/modules/story_sampler.html
+++ b/modules/story_sampler.html
@@ -12,7 +12,7 @@
 <body>
 <div id="storySampler">
   <h2>Story Sampler</h2>
-  <button id="newStoryBtn">Neuen Vorschlag anzeigen</button>
+  <button class="btn" id="newStoryBtn" aria-label="Neuen Vorschlag anzeigen">Neuen Vorschlag anzeigen</button>
   <div id="storyOutput" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/todo_list.html
+++ b/modules/todo_list.html
@@ -18,8 +18,8 @@
   <label for="task-input">Aufgabe:</label>
   <input id="task-input" type="text" aria-label="Neue Aufgabe" placeholder="z.B. Recherche" required>
   <div style="display:flex;gap:.5rem;flex-wrap:wrap;">
-    <button id="add-btn" title="Aufgabe speichern">Hinzufügen</button>
-    <button id="export-btn" title="Liste exportieren">Exportieren</button>
+    <button class="btn" id="add-btn" title="Aufgabe speichern" aria-label="Hinzufügen">Hinzufügen</button>
+    <button class="btn" id="export-btn" title="Liste exportieren" aria-label="Exportieren">Exportieren</button>
   </div>
   <ul id="task-list"></ul>
   <div id="status" role="status" aria-live="polite"></div>

--- a/modules/tooltip_academy.html
+++ b/modules/tooltip_academy.html
@@ -20,7 +20,7 @@
       <li><b>Strg+S</b> speichert deine Eingaben (Shortcut = Tastenkürzel).</li>
       <li>Mit <b>git status</b> siehst du geänderte Dateien.</li>
     </ul>
-    <button id="ttClose">Alles klar</button>
+    <button class="btn" id="ttClose" aria-label="Alles klar">Alles klar</button>
   </div>
 </div>
 <script type="module">

--- a/modules/unsaved_changes_warning.html
+++ b/modules/unsaved_changes_warning.html
@@ -14,7 +14,7 @@
 <div id="ucw">
   <h2>Notizen</h2>
   <textarea id="text" aria-label="Textbereich"></textarea>
-  <button id="save-btn">Speichern</button>
+  <button class="btn" id="save-btn" aria-label="Speichern">Speichern</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>
 <script type="module">

--- a/modules/zip_backup.html
+++ b/modules/zip_backup.html
@@ -13,7 +13,7 @@
 <body>
 <div id="zipBackup">
   <h2>ZIP-Backup</h2>
-  <button id="saveZipBtn">Backup herunterladen</button>
+  <button class="btn" id="saveZipBtn" aria-label="Backup herunterladen">Backup herunterladen</button>
   <input type="file" id="loadZipInput" accept="application/zip">
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -203,10 +203,10 @@
 
 - [ ] Kontrastwerte nach WCAG pruefen (Kontrast = Unterschied zwischen Vorder- und Hintergrund). Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html`
 - [x] Einheitliche Schriftgroesse per CSS-Variable `--base-font` in index-MODULTOOL.html setzen (base-font = Grundschrift).
-- [ ] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
+- [x] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
 - [x] Grid-Layout mit `grid-template-columns: repeat(auto-fit, minmax(320px,1fr))` in modules/common.css erweitern (Grid = Raster zur Anordnung).
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
-- [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
+- [x] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
 - [x] Startskript über npm start verfügbar
 - [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt

--- a/todo.txt
+++ b/todo.txt
@@ -203,10 +203,10 @@
 
 - [ ] Kontrastwerte nach WCAG pruefen (Kontrast = Unterschied zwischen Vorder- und Hintergrund). Befehl: `npx lighthouse http://localhost:8000/index-MODULTOOL.html`
 - [x] Einheitliche Schriftgroesse per CSS-Variable `--base-font` in index-MODULTOOL.html setzen (base-font = Grundschrift).
-- [ ] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
+- [x] Buttons und Links mit `aria-label` ergaenzen (ARIA = zusaetzliche Bildschirmleser-Beschreibung).
 - [x] Grid-Layout mit `grid-template-columns: repeat(auto-fit, minmax(320px,1fr))` in modules/common.css erweitern (Grid = Raster zur Anordnung).
 - [x] Theme-Farben zentral in modules/common.css definieren (Theme = Farbpalette).
-- [ ] Schaltflaechen-Stil zentral in modules/common.css definieren
+- [x] Schaltflaechen-Stil zentral in modules/common.css definieren
 - [x] Story-Sampler-Modul ergänzt
 - [x] Startskript über npm start verfügbar
 - [x] Abschnitt "Updates und Versionen" in LAIENHILFE ergänzt


### PR DESCRIPTION
## Summary
- add consistent `.btn` style and aria-label attributes for accessibility
- extend help doc with more beginner tips
- sync todo lists after updating items

## Testing
- `bash tools/selfcheck.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b6f580ef48325a1e10150d6d267f1