### PR TITLE
Add feedback panel and new themes

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1829,5 +1829,21 @@ Die Tipps erscheinen nur beim ersten Aufruf.
   ```bash
   npm update
   ```
-  *(Lädt aktuelle Versionen aller Abhängigkeiten.)*
+*(Lädt aktuelle Versionen aller Abhängigkeiten.)*
+
+- **Feedback senden (R\u00fcckmeldung)**
+  ```bash
+  # Modul "Nutzer-Feedback" öffnen und Text eingeben
+  # "Senden" klicken, um zu speichern
+  # Mit "Exportieren" lädst du feedback.json herunter
+  ```
+  *(Feedback = Rückmeldung an die Entwickler. Die Einträge bleiben lokal im Browser.)*
+
+- **Anderes Farbschema wählen (Theme)**
+  ```bash
+  # Modul "Theme-Switcher" öffnen
+  # Trash, Kontrast oder Minimal auswählen
+  # Auf "Übernehmen" klicken
+  ```
+  *(Theme = Farb- und Stileinstellung. Die Auswahl wird gespeichert.)*
 

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -242,3 +242,5 @@
 - [ ] Breakpoints feinjustieren und Wide Mode testen
 - [x] Scroll-Cache nutzen und Re-Render minimieren
 - [ ] CSS in Module aufteilen
+- [x] User-Feedback-Panel integrieren
+- [x] Themes Trash/Contrast/Minimal ergänzen

--- a/index-MODULTOOL.html
+++ b/index-MODULTOOL.html
@@ -108,6 +108,96 @@
       --focus-ring: var(--field-border);
       --field-error: #d45e91;
     }
+    [data-theme="trash"] {
+      --bg: #1b1b1b;
+      --area: #2c2c2c;
+      --header: #3d3d3d;
+      --footer: #3d3d3d;
+      --text: #f8f8f8;
+      --text-light: #ccc;
+      --text-alt: #fba55d;
+      --sidebar-bg: #282828f0;
+      --sidebar-txt: #f8f8f8;
+      --sidebar-accent: #e61c5d;
+      --sidebar-divider: #444;
+      --genre-bg: #363636;
+      --input: #3a3a3a;
+      --button: #e61c5d;
+      --button-hover: #b80e4c;
+      --edit: #f0c808;
+      --edit-hover: #e8b200;
+      --remove: #c01c1c;
+      --remove-hover: #9a1010;
+      --help: #252525;
+      --dashboard: #333;
+      --dashboard-light: #444;
+      --tmpl-btn-bg: #5a1a3c;
+      --tmpl-btn-bg-hover: #9a104d;
+      --highlight: #ff2c79;
+      --field-border: #e61c5d;
+      --focus-ring: var(--field-border);
+      --field-error: #ff4c6e;
+    }
+    [data-theme="contrast"] {
+      --bg: #000;
+      --area: #000;
+      --header: #222;
+      --footer: #222;
+      --text: #fff;
+      --text-light: #fff;
+      --text-alt: #ff0;
+      --sidebar-bg: #000;
+      --sidebar-txt: #fff;
+      --sidebar-accent: #0f0;
+      --sidebar-divider: #555;
+      --genre-bg: #111;
+      --input: #222;
+      --button: #ff0;
+      --button-hover: #ffa500;
+      --edit: #0ff;
+      --edit-hover: #0af;
+      --remove: #f00;
+      --remove-hover: #c00;
+      --help: #333;
+      --dashboard: #111;
+      --dashboard-light: #222;
+      --tmpl-btn-bg: #330;
+      --tmpl-btn-bg-hover: #550;
+      --highlight: #f00;
+      --field-border: #0f0;
+      --focus-ring: var(--field-border);
+      --field-error: #f00;
+    }
+    [data-theme="minimal"] {
+      --bg: #ffffff;
+      --area: #f5f5f5;
+      --header: #ffffff;
+      --footer: #ffffff;
+      --text: #000000;
+      --text-light: #444444;
+      --text-alt: #006600;
+      --sidebar-bg: #eeeeee;
+      --sidebar-txt: #111111;
+      --sidebar-accent: #666666;
+      --sidebar-divider: #cccccc;
+      --genre-bg: #f5f5f5;
+      --input: #ffffff;
+      --button: #aaaaaa;
+      --button-hover: #888888;
+      --edit: #0066cc;
+      --edit-hover: #005499;
+      --remove: #cc3333;
+      --remove-hover: #991111;
+      --help: #dddddd;
+      --dashboard: #eeeeee;
+      --dashboard-light: #f5f5f5;
+      --tmpl-btn-bg: #dddddd;
+      --tmpl-btn-bg-hover: #cccccc;
+      --highlight: #0066cc;
+      --field-border: #aaaaaa;
+      --focus-ring: var(--field-border);
+      --field-error: #cc3333;
+    }
 
     html, body {
       min-height: 100vh; width: 100vw; background: var(--bg); color: var(--text); margin:0; padding:0;
@@ -569,7 +659,10 @@ function switchFokus(mode) {
 const themes = [
   {name:'Dunkel', key:'default'},
   {name:'Hell', key:'light'},
-  {name:'Blau', key:'blue'}
+  {name:'Blau', key:'blue'},
+  {name:'Trash', key:'trash'},
+  {name:'Kontrast', key:'contrast'},
+  {name:'Minimal', key:'minimal'}
 ];
 let curTheme = localStorage.getItem('themePppoppi')||'default';
 function renderThemeBtnGroup() {

--- a/module_versions.json
+++ b/module_versions.json
@@ -16,5 +16,6 @@
   "quotes": "1.1",
   "todo": "1.1",
   "unsaved": "1.0",
-  "contrast": "1.0"
+  "contrast": "1.0",
+  "feedback": "1.0"
 }

--- a/modules.json
+++ b/modules.json
@@ -109,6 +109,11 @@
       "id": "tooltip",
       "title": "Tooltip Akademie",
       "file": "modules/tooltip_academy.html"
+    },
+    {
+      "id": "feedback",
+      "title": "Nutzer-Feedback",
+      "file": "modules/user_feedback.html"
     }
   ]
 }

--- a/modules/panel08.html
+++ b/modules/panel08.html
@@ -14,11 +14,14 @@
 <div id="panel08">
   <h2>Theme wählen</h2>
   <label for="theme-select">Farbmodus:</label>
-  <select id="theme-select" aria-label="Theme-Auswahl">
-    <option value="default">Dunkel</option>
-    <option value="light">Hell</option>
-    <option value="blue">Blau</option>
-  </select>
+    <select id="theme-select" aria-label="Theme-Auswahl">
+      <option value="default">Dunkel</option>
+      <option value="light">Hell</option>
+      <option value="blue">Blau</option>
+      <option value="trash">Trash</option>
+      <option value="contrast">Kontrast</option>
+      <option value="minimal">Minimal</option>
+    </select>
   <button class="btn" id="apply-btn" aria-label="Übernehmen">Übernehmen</button>
   <div id="status" role="status" aria-live="polite"></div>
 </div>

--- a/modules/user_feedback.html
+++ b/modules/user_feedback.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Nutzer-Feedback</title>
+<style>
+  #feedback-panel{display:grid;gap:.5rem;max-width:340px;margin:auto;font-family:var(--font-family,sans-serif);}
+  textarea{min-height:6rem;}
+  button{font-size:var(--base-font,1rem);border-radius:var(--btn-radius,.5rem);line-height:1.4;}
+  button:focus-visible{outline:2px solid var(--focus-ring,#005fcc);outline-offset:2px;}
+  @media(min-width:600px){#feedback-panel{max-width:520px;}}
+</style>
+</head>
+<body>
+<div id="feedback-panel">
+  <h2>Feedback</h2>
+  <label for="feedback-text">Dein Feedback:</label>
+  <textarea id="feedback-text" aria-label="Feedback" placeholder="Schreibe hier deine Meinung"></textarea>
+  <button class="btn" id="send-btn" aria-label="Feedback senden">Senden</button>
+  <button class="btn" id="export-btn" aria-label="Feedback exportieren">Exportieren</button>
+  <div id="status" role="status" aria-live="polite"></div>
+</div>
+<script type="module">
+import { showStatus } from './common.js';
+const STORE_KEY='userFeedback';
+const text=document.getElementById('feedback-text');
+const sendBtn=document.getElementById('send-btn');
+const exportBtn=document.getElementById('export-btn');
+const status=document.getElementById('status');
+function load(){try{return JSON.parse(localStorage.getItem(STORE_KEY))||[];}catch{return[];}}
+function save(arr){try{localStorage.setItem(STORE_KEY,JSON.stringify(arr));}catch{showStatus(status,'Speichern fehlgeschlagen');}}
+sendBtn.addEventListener('click',()=>{
+  const t=text.value.trim();
+  if(!t){showStatus(status,'Kein Text eingegeben');return;}
+  const arr=load();
+  arr.push({time:new Date().toLocaleString(),text:t});
+  save(arr);
+  text.value='';
+  showStatus(status,'Danke f\u00fcr dein Feedback!');
+});
+exportBtn.addEventListener('click',()=>{
+  const data=JSON.stringify(load(),null,2);
+  const blob=new Blob([data],{type:'application/json'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download='feedback.json';
+  a.click();
+  setTimeout(()=>URL.revokeObjectURL(a.href),1000);
+});
+</script>
+</body>
+</html>

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -242,3 +242,5 @@
 - [ ] Breakpoints feinjustieren und Wide Mode testen
 - [x] Scroll-Cache nutzen und Re-Render minimieren
 - [ ] CSS in Module aufteilen
+- [x] User-Feedback-Panel integrieren
+- [x] Themes Trash/Contrast/Minimal ergänzen

--- a/plugins/feedback/plugin.json
+++ b/plugins/feedback/plugin.json
@@ -1,0 +1,5 @@
+{
+  "id": "feedback",
+  "name": "Nutzer-Feedback",
+  "version": "1.0.0"
+}

--- a/todo.txt
+++ b/todo.txt
@@ -242,3 +242,5 @@
 - [ ] Breakpoints feinjustieren und Wide Mode testen
 - [x] Scroll-Cache nutzen und Re-Render minimieren
 - [ ] CSS in Module aufteilen
+- [x] User-Feedback-Panel integrieren
+- [x] Themes Trash/Contrast/Minimal ergänzen


### PR DESCRIPTION
## Summary
- add user feedback panel for storing comments in the browser
- register new module and version
- support Trash, Contrast and Minimal themes
- show new theme options in theme switcher
- document feedback feature and themes in LAIENHILFE
- update todo lists

## Testing
- `npm test`
- `bash tools/selfcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_687b76310c488325bc3eb8429f38c01c