### PR TITLE
Implement a11y report tool and unify module template

### DIFF
--- a/LAIENHILFE.md
+++ b/LAIENHILFE.md
@@ -1831,3 +1831,12 @@ Die Tipps erscheinen nur beim ersten Aufruf.
   ```
   *(Lädt aktuelle Versionen aller Abhängigkeiten.)*
 
+
+## Neuer Barrierefreiheits-Report
+
+- **Automatische Zugänglichkeitsprüfung (Accessibility = Barrierefreiheit)**
+  ```bash
+  bash tools/a11y_report.sh
+  ```
+  *(Prüft alle Module mit dem Programm "axe-core" und erstellt einen Bericht im Ordner `logs/a11y`.)*
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Der Selfcheck (`bash tools/selfcheck.sh`) fungiert als einfacher HTML-Fehler-Che
 
 - Drag & Drop für Medien, Module, Templates
 - Undo-/Redo-System, ZIP-Export, Selfcheck (Fehlerprüfung via `bash tools/selfcheck.sh`)
+- Barrierefreiheits-Report mit `bash tools/a11y_report.sh`
 - Filter für Module und Favoritenliste im Menü
 - Scrollsync zwischen den Panels (gemeinsame Scroll-Position)
 - Live-Vorschau, große Bedienelemente, Einstellungs-Panel

--- a/data/todo.txt
+++ b/data/todo.txt
@@ -60,6 +60,7 @@
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
 - [ ] Templates-Modul (Panel02) erstellen
+- [x] Modul-Template vereinheitlichen (gemeinsames API und Fehleranzeige)
 - [ ] Undo/Redo-System einbauen
 - [x] ZIP-Backup-Funktion ergänzen
 
@@ -87,7 +88,9 @@
 - [x] Unit- und Integrationstests einrichten
 - [x] GitHub Actions für Linting und Testing hinzufügen
 - [ ] Schritt-für-Schritt-Assistenten für Modul-Erstellung planen
-- [ ] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheits-Report-Tool (a11y_report.sh) erstellen
+- [ ] Barrierefreiheits-Report regelmäßig per Cronjob ausführen
 
 - [ ] Unnötige Platzhalter-Dateien entfernen
 - [x] GitHub-Workflow test.yml für automatische Prüfungen

--- a/modules/panel_template.html
+++ b/modules/panel_template.html
@@ -9,9 +9,15 @@
 </style>
 </head>
 <body>
-<div id="{{ID}}">
+<div id="{{ID}}" class="mod-panel">
   <h2>{{TITLE}}</h2>
+  <div id="status" role="status" aria-live="polite"></div>
   <!-- Hier kommt dein Inhalt hin -->
 </div>
+<script type="module">
+import { showStatus, handleError } from './common.js';
+window.showStatus = showStatus;
+window.handleError = handleError;
+</script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^24.0.14",
+        "axe-core": "^4.7.0",
         "mocha": "^11.7.1",
         "node-localstorage": "^3.0.5",
         "typescript": "^5.2.2"
@@ -88,6 +89,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^24.0.14",
     "mocha": "^11.7.1",
     "node-localstorage": "^3.0.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "axe-core": "^4.7.0"
   }
 }

--- a/platzhalter.txt
+++ b/platzhalter.txt
@@ -60,6 +60,7 @@
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
 - [ ] Templates-Modul (Panel02) erstellen
+- [x] Modul-Template vereinheitlichen (gemeinsames API und Fehleranzeige)
 - [ ] Undo/Redo-System einbauen
 - [x] ZIP-Backup-Funktion ergänzen
 
@@ -87,7 +88,9 @@
 - [x] Unit- und Integrationstests einrichten
 - [x] GitHub Actions für Linting und Testing hinzufügen
 - [ ] Schritt-für-Schritt-Assistenten für Modul-Erstellung planen
-- [ ] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheits-Report-Tool (a11y_report.sh) erstellen
+- [ ] Barrierefreiheits-Report regelmäßig per Cronjob ausführen
 
 - [ ] Unnötige Platzhalter-Dateien entfernen
 - [x] GitHub-Workflow test.yml für automatische Prüfungen

--- a/todo.txt
+++ b/todo.txt
@@ -60,6 +60,7 @@
 - MIT-Lizenz hinzugefuegt (LICENSE-Datei, Verweis in README)
 - AGENTS.md Codeblock geschlossen (triple backticks).
 - [ ] Templates-Modul (Panel02) erstellen
+- [x] Modul-Template vereinheitlichen (gemeinsames API und Fehleranzeige)
 - [ ] Undo/Redo-System einbauen
 - [x] ZIP-Backup-Funktion ergänzen
 
@@ -87,7 +88,9 @@
 - [x] Unit- und Integrationstests einrichten
 - [x] GitHub Actions für Linting und Testing hinzufügen
 - [ ] Schritt-für-Schritt-Assistenten für Modul-Erstellung planen
-- [ ] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheit automatisch prüfen (axe-core)
+- [x] Barrierefreiheits-Report-Tool (a11y_report.sh) erstellen
+- [ ] Barrierefreiheits-Report regelmäßig per Cronjob ausführen
 
 - [ ] Unnötige Platzhalter-Dateien entfernen
 - [x] GitHub-Workflow test.yml für automatische Prüfungen

--- a/tools/a11y_report.sh
+++ b/tools/a11y_report.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# tools/a11y_report.sh - erstellt Barrierefreiheits-Berichte mit axe-core
+
+PORT=${1:-8000}
+DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+cd "$DIR" || exit 1
+
+LOGDIR="logs/a11y"
+mkdir -p "$LOGDIR"
+
+python3 -m http.server "$PORT" >/tmp/a11y_server.log 2>&1 &
+PID=$!
+sleep 2
+
+for file in index-MODULTOOL.html modules/*.html panels/*.html; do
+  [ -f "$file" ] || continue
+  OUT="$LOGDIR/$(basename "$file" .html)_report.txt"
+  npx axe "http://localhost:$PORT/$file" --quiet > "$OUT" 2>&1 || echo "Fehler bei $file" >> "$OUT"
+done
+
+kill $PID
+
+echo "📝 Berichte liegen in $LOGDIR"


### PR DESCRIPTION
## Summary
- add script `a11y_report.sh` for generating accessibility reports
- register axe-core as dev dependency
- update module template with status area and helper imports
- document the new report tool in README and LAIENHILFE
- update todo lists

## Testing
- `npm test`
- `bash tools/selfcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_687b769c89c08325be450c38855a0e88